### PR TITLE
Update avatar menu; fix Saved&Read URL

### DIFF
--- a/packages/lesswrong/components/users/UsersMenu.tsx
+++ b/packages/lesswrong/components/users/UsersMenu.tsx
@@ -213,35 +213,13 @@ const UsersMenu = ({classes}: {
                   }
                 />
               }
-              {!isEAForum &&
-                <DropdownItem
-                  title={preferredHeadingCase("My Drafts")}
-                  to="/drafts"
-                  icon="Edit"
-                  iconClassName={classes.icon}
-                />
-              }
               {!currentUser.deleted &&
                 <DropdownItem
-                  title={preferredHeadingCase("User Profile")}
+                  title={preferredHeadingCase("Profile")}
                   to={`/users/${currentUser.slug}`}
                   icon="User"
                   iconClassName={classes.icon}
                 />
-              }
-              {userHasThemePicker(currentUser) &&
-                <ThemePickerMenu>
-                  <DropdownItem
-                    title="Theme"
-                    onClick={(ev) => {
-                      if (isMobile()) {
-                        ev.stopPropagation();
-                      }
-                    }}
-                    icon="Puzzle"
-                    iconClassName={classes.icon}
-                  />
-                </ThemePickerMenu>
               }
               {/* TODO un-admin gate when ready for production use */}
               {isEAForum && userIsAdminOrMod(currentUser) && <DropdownItem
@@ -253,7 +231,7 @@ const UsersMenu = ({classes}: {
               {!isFriendlyUI && accountSettingsNode}
               {!isFriendlyUI && messagesNode}
               <DropdownItem
-                title={isFriendlyUI ? "Saved & read" : "Bookmarks"}
+                title={isFriendlyUI ? "Saved & Read" : "Bookmarks"}
                 to={isFriendlyUI ? "/saved" : "/bookmarks"}
                 icon="Bookmarks"
                 iconClassName={classes.icon}

--- a/packages/lesswrong/lib/routes.ts
+++ b/packages/lesswrong/lib/routes.ts
@@ -1132,10 +1132,10 @@ const eaLwAfForumSpecificRoutes = forumSelect<Route[]>({
       background: postBackground
     },
     {
-      name: 'bookmarks',
-      path: '/bookmarks',
+      name: 'savedAndRead',
+      path: '/saved',
       componentName: 'BookmarksPage',
-      title: 'Bookmarks',
+      title: 'Saved & Read',
     },
   ],
   default: [


### PR DESCRIPTION
This removes the Drafts and Theme options from the avatar menu, updates the names of Profile and "Saved & Read", and also fixes the URL of the "Saved & Read" page.

([Here's the associated ClickUp task](https://app.clickup.com/t/8685brpmv))