### PR TITLE
Change Create Post button hover color

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -118,9 +118,6 @@ const styles = (theme: ThemeType): JssStyles => ({
     top: 13,
     right: 15,
     color: "#fff",
-    "&:hover": {
-      background: theme.palette.primary.light,
-    },
   },
 })
 
@@ -198,6 +195,8 @@ const HomeLatestPosts = ({classes}:{classes: ClassesType}) => {
             <Button
               type="button"
               className={classes.createPostButton}
+              variant="contained"
+              color="primary"
             >
               Create Post
             </Button>


### PR DESCRIPTION
Change Create Post button (the one on top middle of the home page) from weird cyan to muted blue. ([This is the associated ClickUp task](https://app.clickup.com/t/86861mfvd).)