### PR TITLE
Fix integration tests

### DIFF
--- a/packages/lesswrong/integrationTests/moderation.server.tests.ts
+++ b/packages/lesswrong/integrationTests/moderation.server.tests.ts
@@ -212,23 +212,24 @@ describe('User moderation fields --', () => {
     const expectedOutput = { data: { updateUser: {data: { moderationStyle: "easy-going" } } } }
     return (response as any).should.eventually.deep.equal(expectedOutput);
   });
-  it("non-trusted users can set their moderationGuidelines", async () => {
-    const user = await createDummyUser()
-    const query = `
-      mutation UsersUpdate {
-        updateUser(selector: {_id: "${user._id}"}, data: {moderationGuidelines: {originalContents: {type: "markdown", data: "blah"}}}) {
-          data {
-            moderationGuidelines {
-              markdown
-            }
-          }
-        }
-      }
-    `;
-    const response = runQuery(query, {}, {currentUser:user})
-    const expectedOutput = { data: { updateUser: { data: {moderationGuidelines: {markdown: "blah"} } } } }
-    return (response as any).should.eventually.deep.equal(expectedOutput);
-  });
+  /* Waking Up forum users don't change their moderationGuidelines, so this is commented out */
+  // it("non-trusted users can set their moderationGuidelines", async () => {
+  //   const user = await createDummyUser()
+  //   const query = `
+  //     mutation UsersUpdate {
+  //       updateUser(selector: {_id: "${user._id}"}, data: {moderationGuidelines: {originalContents: {type: "markdown", data: "blah"}}}) {
+  //         data {
+  //           moderationGuidelines {
+  //             markdown
+  //           }
+  //         }
+  //       }
+  //     }
+  //   `;
+  //   const response = runQuery(query, {}, {currentUser:user})
+  //   const expectedOutput = { data: { updateUser: { data: {moderationGuidelines: {markdown: "blah"} } } } }
+  //   return (response as any).should.eventually.deep.equal(expectedOutput);
+  // });
   it("non-trusted users can set their moderatorAssistance", async () => {
     const user = await createDummyUser()
     const query = `
@@ -259,23 +260,24 @@ describe('User moderation fields --', () => {
     const expectedOutput = { data: { updateUser: {data: { moderationStyle: "easy-going" } } } }
     return (response as any).should.eventually.deep.equal(expectedOutput);
   });
-  it("trusted users can set their moderationGuidelines", async () => {
-    const user = await createDummyUser({groups:["trustLevel1"]})
-    const query = `
-      mutation UsersUpdate {
-        updateUser(selector: {_id: "${user._id}"}, data: {moderationGuidelines: {originalContents: {type: "markdown", data: "blah"}}}) {
-          data {
-            moderationGuidelines {
-              markdown
-            }
-          }
-        }
-      }
-    `;
-    const response = runQuery(query, {}, {currentUser:user})
-    const expectedOutput = { data: { updateUser: { data: {moderationGuidelines: {markdown: "blah"}} } } }
-    return (response as any).should.eventually.deep.equal(expectedOutput);
-  });
+  /* Waking Up forum users don't change their moderationGuidelines, so this is commented out */
+  // it("trusted users can set their moderationGuidelines", async () => {
+  //   const user = await createDummyUser({groups:["trustLevel1"]})
+  //   const query = `
+  //     mutation UsersUpdate {
+  //       updateUser(selector: {_id: "${user._id}"}, data: {moderationGuidelines: {originalContents: {type: "markdown", data: "blah"}}}) {
+  //         data {
+  //           moderationGuidelines {
+  //             markdown
+  //           }
+  //         }
+  //       }
+  //     }
+  //   `;
+  //   const response = runQuery(query, {}, {currentUser:user})
+  //   const expectedOutput = { data: { updateUser: { data: {moderationGuidelines: {markdown: "blah"}} } } }
+  //   return (response as any).should.eventually.deep.equal(expectedOutput);
+  // });
   it("trusted users can set their moderatorAssistance", async () => {
     const user = await createDummyUser({groups:["trustLevel1"]})
     const query = `


### PR DESCRIPTION
Waking Up doesn't use strong votes, and that change broke the performVoteServer / 'sets post to active after voting' test.

Waking Up users can't change moderation guidelines, which broke two "users can set their moderationGuidelines" tests.

This PR alters the tests and includes long comments explaining the changes. (The long comment should make it easier to figure out what to do about any merge conflicts that might arise when getting changes from upstream.)

There are GitHub Actions that run tests after each push. The integration tests have been broken for a while so we've been ignoring the results, but after this PR is merged, we should watch out for broken integration tests. (Unfortunately, the Cypress tests are still broken.)