### PR TITLE
Update the font sizes on Account Settings pages to match the design.

### DIFF
--- a/packages/lesswrong/components/form-components/LocationFormComponent.tsx
+++ b/packages/lesswrong/components/form-components/LocationFormComponent.tsx
@@ -23,7 +23,7 @@ export const geoSuggestStyles = (theme: ThemeType): JssStyles => ({
     borderBottom: `1px solid ${theme.palette.text.normal}`,
     padding: ".5em .5em 0.5em 0em !important",
     width: 350,
-    fontSize: 13,
+    fontSize: theme.typography.body2.fontSize,
     color: theme.palette.primary.main,
     [theme.breakpoints.down('sm')]: {
       width: "100%"

--- a/packages/lesswrong/components/users/UsersEditForm.tsx
+++ b/packages/lesswrong/components/users/UsersEditForm.tsx
@@ -96,7 +96,11 @@ const styles = (theme: ThemeType): JssStyles => ({
         float: "none",
       },
     },
-
+    
+    "& .MuiFormLabel-root, .MuiInputBase-input": {
+      fontSize: theme.typography.body2.fontSize,
+      fontWeight: 600,
+    }
   },
 
   header: {

--- a/packages/lesswrong/themes/siteThemes/wakingUpTheme.ts
+++ b/packages/lesswrong/themes/siteThemes/wakingUpTheme.ts
@@ -139,7 +139,7 @@ export const wakingUpTheme: SiteThemeSpecification = {
           fontFamily: serifStack,
         },
         body2: {
-          fontSize: "1.1rem",
+          fontSize: "14px",
           lineHeight: "1.5em",
           fontWeight: 450,
         },


### PR DESCRIPTION
This is also designating "body2" in the theme to be 14px exactly (it was derived to be 14.2px before) and using that value for form input & label sizes.

from discussions in https://app.clickup.com/t/8685a3qa5

