### PR TITLE
Add frontpagePostsLoadMoreCountSetting, load correct number of posts

### DIFF
--- a/packages/lesswrong/components/common/HomeLatestPosts.tsx
+++ b/packages/lesswrong/components/common/HomeLatestPosts.tsx
@@ -21,7 +21,7 @@ import { getPostViewOptions } from '../../lib/postViewOptions';
 import Button from '@material-ui/core/Button';
 import qs from 'qs'
 import { Link } from '../../lib/reactRouterWrapper';
-import { frontpagePostsCountSetting } from '../../lib/publicSettings';
+import { frontpagePostsCountSetting, frontpagePostsLoadMoreCountSetting } from '../../lib/publicSettings';
 
 const titleWrapper = isLW ? {
   marginBottom: 8
@@ -181,7 +181,6 @@ const HomeLatestPosts = ({classes}:{classes: ClassesType}) => {
     view: currentSorting,
     forum: true,
     limit:limit,
-    itemsPerPage: frontpagePostsCountSetting.get() ?? 25,
   }
 
   const showCurated = isFriendlyUI || (isLW && reviewIsActive())
@@ -220,6 +219,7 @@ const HomeLatestPosts = ({classes}:{classes: ClassesType}) => {
                 terms={postsTerms}
                 alwaysShowLoadMore
                 hideHiddenFrontPagePosts
+                itemsPerPage={frontpagePostsLoadMoreCountSetting.get()}
               >
               </PostsList2>
             </AllowHidingFrontPagePostsContext.Provider>

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -163,5 +163,6 @@ export const showSocialMediaShareLinksSetting = new DatabasePublicSetting<boolea
 
 export const hasCookieConsentSetting = new DatabasePublicSetting<boolean>('hasCookieConsent', false);
 export const frontpagePostsCountSetting = new DatabasePublicSetting<number | null>('frontpagePostsCount', null)
+export const frontpagePostsLoadMoreCountSetting = new DatabasePublicSetting<number | undefined>('frontpagePostsLoadMoreCount', undefined)
 export const showPersonalBlogpostIconSetting = new DatabasePublicSetting<boolean>('showPersonalBlogpostIcon', true);
 export const showFirstPostReviewMessageSetting = new DatabasePublicSetting<boolean>('showFirstPostReviewMessage', true);


### PR DESCRIPTION
The Load More button was still retrieving the default number of posts (25), because itemsPerPage was being set in the wrong place (`terms` rather than `props`), as described in [the ClickUp issue](https://app.clickup.com/t/868628qy7) (though Jeremy approved it anyway). I fixed that, and also made it a setting.