### PR TITLE
Add showKarmaTooltipsSetting to set whether karma tooltips show

### DIFF
--- a/packages/lesswrong/components/common/KarmaDisplay.tsx
+++ b/packages/lesswrong/components/common/KarmaDisplay.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import type { PopperPlacementType } from "@material-ui/core/Popper";
 import { forumTypeSetting } from "../../lib/instanceSettings";
+import { showKarmaTooltipsSetting } from "../../lib/publicSettings";
 
 const KarmaDisplay = ({document, placement="left"}: {
   document: VoteableType,
@@ -14,18 +15,20 @@ const KarmaDisplay = ({document, placement="left"}: {
     ? document.afBaseScore
     : null;
   const {LWTooltip} = Components;
+
+  const title = showKarmaTooltipsSetting.get() &&
+    <div>
+      <div>{baseScore ?? 0} karma</div>
+      <div>({document.voteCount} votes)</div>
+      {afBaseScore &&
+        <div><em>({afBaseScore} karma on AlignmentForum.org)</em></div>
+      }
+    </div>
+
   return (
     <LWTooltip
       placement={placement}
-      title={
-        <div>
-          <div>{baseScore ?? 0} karma</div>
-          <div>({document.voteCount} votes)</div>
-          {afBaseScore &&
-            <div><em>({afBaseScore} karma on AlignmentForum.org)</em></div>
-          }
-        </div>
-      }
+      title={title}
     >
       {baseScore ?? 0}
     </LWTooltip>

--- a/packages/lesswrong/components/users/EAUserTooltipContent.tsx
+++ b/packages/lesswrong/components/users/EAUserTooltipContent.tsx
@@ -2,12 +2,13 @@ import React, { useMemo } from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
 import { htmlToTextDefault } from "../../lib/htmlToText";
 import moment from "moment";
+import { showKarmaTooltipsSetting } from "../../lib/publicSettings";
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
     display: "flex",
     flexDirection: "column",
-    width: 270,
+    width: showKarmaTooltipsSetting.get() ? 270 : 200,
     maxWidth: "100%",
     gap: "12px",
     fontSize: 14,
@@ -124,10 +125,10 @@ const EAUserTooltipContent = ({user, classes}: {
         </div>
       }
       <div className={classes.stats}>
-        <div className={classes.stat}>
+        {showKarmaTooltipsSetting.get() && <div className={classes.stat}>
           <div>{formatStat(karma)}</div>
           <div>Karma</div>
-        </div>
+        </div>}
         <div className={classes.stat}>
           <div>{formatStat(postCount)}</div>
           <div>{postCount === 1 ? "Post" : "Posts"}</div>

--- a/packages/lesswrong/components/votes/OverallVoteAxis.tsx
+++ b/packages/lesswrong/components/votes/OverallVoteAxis.tsx
@@ -12,6 +12,7 @@ import type { VotingProps } from './votingProps';
 import type { OverallVoteButtonProps } from './OverallVoteButton';
 import classNames from 'classnames';
 import { isFriendlyUI } from '../../themes/forumTheme';
+import { showKarmaTooltipsSetting } from '../../lib/publicSettings';
 
 const styles = (theme: ThemeType): JssStyles => ({
   overallSection: {
@@ -122,7 +123,7 @@ const OverallVoteAxis = ({
       popperClassName={classes.tooltip}
       title={<>
         <div>{whyYouCantVote}</div>
-        <div>{karmaTooltipTitle}</div>
+        {showKarmaTooltipsSetting.get() && <div>{karmaTooltipTitle}</div>}
       </>}
     >
       {children}
@@ -186,7 +187,7 @@ const OverallVoteAxis = ({
             {...voteProps}
             {...buttonProps}
           />
-          <TooltipIfEnabled title={karmaTooltipTitle} placement={tooltipPlacement}>
+          <TooltipIfEnabled title={showKarmaTooltipsSetting.get() && karmaTooltipTitle} placement={tooltipPlacement}>
             {hideKarma
               ? <span>{' '}</span>
               : <span className={classes.voteScore}>

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -169,3 +169,4 @@ export const frontpagePostsCountSetting = new DatabasePublicSetting<number | nul
 export const frontpagePostsLoadMoreCountSetting = new DatabasePublicSetting<number | undefined>('frontpagePostsLoadMoreCount', undefined)
 export const showPersonalBlogpostIconSetting = new DatabasePublicSetting<boolean>('showPersonalBlogpostIcon', true);
 export const showFirstPostReviewMessageSetting = new DatabasePublicSetting<boolean>('showFirstPostReviewMessage', true);
+export const showKarmaTooltipsSetting = new DatabasePublicSetting<boolean>('showKarmaTooltips', true);


### PR DESCRIPTION
This PR adds a setting so we can remove karma tooltips as specified in [this ClickUp task](https://app.clickup.com/t/8685tmx38) and [this ClickUp task](https://app.clickup.com/t/86861e679).

(Update: now linked the correct second ClickUp task)