### PR TITLE
Update copy for new user mouseover; use EA/Friendly criteria

### DIFF
--- a/packages/lesswrong/components/users/UserCommentMarkers.tsx
+++ b/packages/lesswrong/components/users/UserCommentMarkers.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { registerComponent, Components } from "../../lib/vulcan-lib";
-import { siteNameWithArticleSetting } from "../../lib/instanceSettings";
 import { isNewUser } from "../../lib/collections/users/helpers";
 import { isFriendlyUI } from "../../themes/forumTheme";
 
@@ -58,7 +57,7 @@ const UserCommentMarkers = ({
       {showNewUserIcon &&
         <LWTooltip
           placement="bottom-start"
-          title={`${user.displayName} is either new on ${siteNameWithArticleSetting.get()} or doesn't have much karma yet.`}
+          title={`This is ${user.displayName}'s first week on the forum.`}
           className={classes.iconWrapper}
         >
           <ForumIcon icon="Sprout" className={classes.sproutIcon} />

--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -11,6 +11,7 @@ import type { PermissionResult } from '../../make_voteable';
 import { DatabasePublicSetting } from '../../publicSettings';
 import moment from 'moment';
 import { MODERATOR_ACTION_TYPES } from '../moderatorActions/schema';
+import { isFriendlyUI } from '../../../themes/forumTheme';
 
 const newUserIconKarmaThresholdSetting = new DatabasePublicSetting<number|null>('newUserIconKarmaThreshold', null)
 
@@ -52,7 +53,7 @@ export const isNewUser = (user: UsersMinimumInfo): boolean => {
   // For the EA forum, return true if either:
   // 1. the user is below the karma threshold, or
   // 2. the user was created less than a week ago
-  if (isEAForum) {
+  if (isFriendlyUI) {
     return userBelowKarmaThreshold || moment(user.createdAt).isAfter(moment().subtract(1, "week"));
   }
 


### PR DESCRIPTION
As described in [this ClickUp task](https://app.clickup.com/t/868625apn), this PR updates the copy for the tooltip for new user icons, and changes the criteria for who counts as a new user, i.e. everyone whose account is under a week old.

(In ForumCredentials, I'm removing the value for newUserIconKarmaThresholdSetting to remove the karma check.)