### PR TITLE
Remove New Posts notifications

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsMenu.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsMenu.tsx
@@ -85,11 +85,6 @@ const NotificationsMenu = ({ unreadPrivateMessages, open, setIsOpen, hasOpened, 
       terms: {view: "userNotifications"},
     },
     {
-      name: "New Posts",
-      icon: () => (<PostsIcon classes={{root: classes.icon}}/>),
-      terms: {view: 'userNotifications', type: "newPost"},
-    },
-    {
       name: "New Comments",
       icon: () => (<CommentsIcon classes={{root: classes.icon}}/>),
       terms: {view: 'userNotifications', type: "newComment"},


### PR DESCRIPTION
This PR removes the New Posts notifications as described in [this ClickUp task](https://app.clickup.com/t/86860y92m).

It's just a simple deletion, when it could be a setting. It felt like it'd be kinda weird to have NewPostNotificationsSetting without corresponding settings for the three other notification types, and adding those settings felt like over-engineering when they'll never be used. tbh, I don't think wanting to merge this change upstream will ever come up, and if we're merging upstream changes with this change, solving a merge conflict shouldn't be hard because it's a very simple and clear change to understand.