### PR TITLE
Tiny change to post locked message

### DIFF
--- a/packages/lesswrong/components/comments/CantCommentExplanation.tsx
+++ b/packages/lesswrong/components/comments/CantCommentExplanation.tsx
@@ -33,7 +33,7 @@ const CantCommentExplanation = ({post, classes}: {
     <div className={classNames("i18n-message", "author_has_banned_you", classes.root)}>
       { userBlockedCommentingReason(currentUser, post, author)}{" "}
       { email && <span>
-        (Questions? Send an email to <a className={classes.emailLink} href={`mailto:${email}`}>{email}</a>)
+        Questions? Send an email to <a className={classes.emailLink} href={`mailto:${email}`}>{email}</a>
       </span> }
     </div>
   );


### PR DESCRIPTION
This PR removes two characters from the message on locked posts. [Here's the ClickUp task](https://app.clickup.com/t/86861npye).