### PR TITLE
Add GitHub workflow to automatically deploy to staging

### DIFF
--- a/.github/workflows/deployWUStaging.yml
+++ b/.github/workflows/deployWUStaging.yml
@@ -1,0 +1,32 @@
+name: Deploy WU Staging
+concurrency: deploy-wu-dev
+on:
+  push:
+    branches: [ waking-up ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+        environment: [Staging-env]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '>=3.5' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+    - run: pip3 install "pyyaml<5.4" && pip3 install --upgrade pip awsebcli # pip3 install "pyyaml<5.4" is a temporary workaround for this bug: https://github.com/aws/aws-elastic-beanstalk-cli/issues/441
+    - name: Run Migrations
+      if: github.ref == 'refs/heads/master'
+      uses: ./.github/actions/runMigrations
+      with:
+        mode: staging
+        credentials-repo: ${{ secrets.WU_CREDENTIALS_REPO }}
+        credentials-pat: ${{ secrets.WU_CREDENTIALS_PAT }}
+        transcrypt-secret: ${{ secrets.WU_TRANSCRYPT_SECRET }}
+    - name: Run Deploy
+      run: scripts/deploy.sh Staging2 ${{ matrix.environment }}
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.WU_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.WU_AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: "us-east-1"


### PR DESCRIPTION
This PR should make GitHub automatically deploy the waking-up branch to the staging server whenever it gets new code. The workflow is basically the same as the EA one, with just a few values changed.

This is [the associated ClickUp task](https://app.clickup.com/t/86866g09g).