### PR TITLE
Remove items from post and comment menus

### DIFF
--- a/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
@@ -20,6 +20,8 @@ const CommentActions = ({currentUser, comment, post, tag, showEdit}: {
     BanUserFromPostDropdownItem, LockThreadDropdownItem,
   } = Components;
 
+  const currentUserIsAuthor = comment.user?._id === currentUser?._id
+
   const {document: postDetails} = useSingle({
     skip: !post,
     documentId: post?._id,
@@ -56,23 +58,11 @@ const CommentActions = ({currentUser, comment, post, tag, showEdit}: {
       <EditCommentDropdownItem comment={comment} showEdit={showEdit} />
       <PinToProfileDropdownItem comment={comment} post={post} />
       <NotifyMeDropdownItem
-        document={post}
-        enabled={enableSubscribeToPost}
-        subscribeMessage={`Subscribe to ${post?.title}`}
-        unsubscribeMessage={`Unsubscribe from ${post?.title}`}
-      />
-      <NotifyMeDropdownItem
         document={comment}
         subscribeMessage="Subscribe to comment replies"
         unsubscribeMessage="Unsubscribe from comment replies"
       />
-      <NotifyMeDropdownItem
-        document={comment.user}
-        enabled={enableSubscribeToCommentUser}
-        subscribeMessage={"Subscribe to posts by " + userGetDisplayName(comment.user)}
-        unsubscribeMessage={"Unsubscribe from posts by " + userGetDisplayName(comment.user)}
-      />
-      <ReportCommentDropdownItem comment={comment} post={post} />
+      {!currentUserIsAuthor && <ReportCommentDropdownItem comment={comment} post={post} />}
       <MoveToAlignmentCommentDropdownItem comment={comment} post={postDetails} />
       <SuggestAlignmentCommentDropdownItem comment={comment} post={postDetails} />
 
@@ -85,7 +75,6 @@ const CommentActions = ({currentUser, comment, post, tag, showEdit}: {
       <MoveToAnswersDropdownItem comment={comment} post={postDetails} />
       <ShortformFrontpageDropdownItem comment={comment} />
       <DeleteCommentDropdownItem comment={comment} post={postDetails} tag={tag} />
-      <RetractCommentDropdownItem comment={comment} />
       <LockThreadDropdownItem comment={comment} />
       <BanUserFromPostDropdownItem comment={comment} post={postDetails} />
       <BanUserFromAllPostsDropdownItem comment={comment} post={postDetails} />

--- a/packages/lesswrong/components/dropdowns/comments/DeleteCommentDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/DeleteCommentDropdownItem.tsx
@@ -53,6 +53,7 @@ const DeleteCommentDropdownItem = ({comment, post, tag}: {
       <DropdownItem
         title="Delete"
         onClick={showDeleteDialog}
+        icon={"Warning"}
       />
     );
   }

--- a/packages/lesswrong/components/dropdowns/comments/PinToProfileDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/PinToProfileDropdownItem.tsx
@@ -40,8 +40,8 @@ const PinToProfileDropdownItem = ({comment, post, classes}: {
     : `${comment.user?.displayName}'s`;
 
   const title = comment.isPinnedOnProfile
-    ? `Unpin from ${username} profile`
-    : `Pin to ${username} profile`;
+    ? `Unpin from profile`
+    : `Pin to profile`;
 
   const {DropdownItem} = Components;
   return (

--- a/packages/lesswrong/components/dropdowns/posts/MoveToDraftDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/MoveToDraftDropdownItem.tsx
@@ -27,6 +27,7 @@ const MoveToDraftDropdownItem = ({ post }: {
       <DropdownItem
         title={preferredHeadingCase("Move to Draft")}
         onClick={handleMoveToDraftDropdownItem}
+        icon={"Document"}
       />
     );
   } else {

--- a/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
@@ -40,6 +40,7 @@ const PostActions = ({post, closeMenu, includeBookmark=true, classes}: {
 
   if (!post) return null;
   const postAuthor = post.user;
+  const currentUserIsAuthor = postAuthor?._id === currentUser?._id
 
   // WARNING: Clickable items in this menu must be full-width, and
   // ideally should use the <DropdownItem> component. In particular,
@@ -57,46 +58,17 @@ const PostActions = ({post, closeMenu, includeBookmark=true, classes}: {
       {isBookUI && shareButtonSetting.get() && <SharePostSubmenu post={post} closeMenu={closeMenu} />}
       <DuplicateEventDropdownItem post={post} />
       <PostAnalyticsDropdownItem post={post} />
-      <NotifyMeDropdownItem
-        document={post.group}
-        enabled={!!post.group}
-        subscribeMessage={`Subscribe to ${post.group?.name}`}
-        unsubscribeMessage={`Unsubscribe from ${post.group?.name}`}
-      />
-      <NotifyMeDropdownItem
-        document={post}
-        enabled={post.shortform && post.userId !== currentUser?._id}
-        subscribeMessage={`Subscribe to ${post.title}`}
-        unsubscribeMessage={`Unsubscribe from ${post.title}`}
-        subscriptionType={subscriptionTypes.newShortform}
-      />
-      <NotifyMeDropdownItem
-        document={postAuthor}
-        enabled={!!postAuthor && postAuthor._id !== currentUser?._id}
-        subscribeMessage={`Subscribe to posts by ${userGetDisplayName(postAuthor)}`}
-        unsubscribeMessage={`Unsubscribe from posts by ${userGetDisplayName(postAuthor)}`}
-      />
-      <NotifyMeDropdownItem
-        document={post}
-        enabled={!!post.debate}
-        subscribeMessage="Subscribe to dialogue"
-        unsubscribeMessage="Unsubscribe from dialogue"
-        subscriptionType={subscriptionTypes.newDebateComments}
-        tooltip="Notifies you when there is new activity in the dialogue"
-      />
-      <NotifyMeDropdownItem
+      {currentUserIsAuthor && <NotifyMeDropdownItem
         document={post}
         subscribeMessage="Subscribe to comments"
         unsubscribeMessage="Unsubscribe from comments"
-      />
-      {includeBookmark && <BookmarkDropdownItem post={post} />}
+      />}
+      {!currentUserIsAuthor && includeBookmark && <BookmarkDropdownItem post={post} />}
       <SetSideCommentVisibility />
-      <HideFrontpagePostDropdownItem post={post} />
-      <ReportPostDropdownItem post={post}/>
+      {!currentUserIsAuthor && <ReportPostDropdownItem post={post}/>}
       {/* Tags (topics) are removed for launch, but will be added back later, so I'm leaving this commented out. */}
       {/*currentUser && <EditTagsDropdownItem post={post} closeMenu={closeMenu} />*/}
       <SummarizeDropdownItem post={post} closeMenu={closeMenu} />
-      {currentUser && <MarkAsReadDropdownItem post={post} />}
       {showCuratedSetting.get() && <SuggestCuratedDropdownItem post={post} />}
       <MoveToDraftDropdownItem post={post} />
       <DeleteDraftDropdownItem post={post} />


### PR DESCRIPTION
This PR removes items from the post and comment menus as specified in [this ClickUp task](https://app.clickup.com/t/8685rfd6p).

At first I tried making each of these items an individual setting, and then considered one setting that's an array of items to exclude, but then there were also new rules around whether it's your post/comment or someone else's, and it all seemed a bit much. So this is just a straightforward change, no settings involved.