### PR TITLE
Don't show the Continue Reading section if it's empty

### DIFF
--- a/packages/lesswrong/components/bookmarks/BookmarksTab.tsx
+++ b/packages/lesswrong/components/bookmarks/BookmarksTab.tsx
@@ -10,8 +10,9 @@ export const BookmarksTab = () => {
 
   return <AnalyticsContext pageSectionContext="bookmarksTab">
     <BookmarksList/>
-    <SectionTitle title="Continue Reading"/>
-    <ContinueReadingList continueReading={continueReading}/>
+    {continueReading?.length > 0 && <><SectionTitle title="Continue Reading"/>
+      <ContinueReadingList continueReading={continueReading}/>
+    </>}
   </AnalyticsContext>
 }
 


### PR DESCRIPTION
As described in [this ClickUp task](https://app.clickup.com/t/86866fqcz) (and comments), the Continue Reading section title still appears for the user's unfinished sequences, even if that list is empty. This PR changes that.