### PR TITLE
Prevent deployment workflow using incompatible Python version

### DIFF
--- a/.github/workflows/deployWUStaging.yml
+++ b/.github/workflows/deployWUStaging.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
       with:
-        python-version: '>=3.5' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+        python-version: '>=3.5 <3.12' # Version range or exact version of a Python version to use, using SemVer's version range syntax
     - run: pip3 install "pyyaml<5.4" && pip3 install --upgrade pip awsebcli # pip3 install "pyyaml<5.4" is a temporary workaround for this bug: https://github.com/aws/aws-elastic-beanstalk-cli/issues/441
     - name: Run Migrations
       if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
The deployment workflow fails because it uses Python 3.12, which lacks the 'imp' module (it was deprecated). This PR prevents Python versions 3.12 and higher being used.

Also I'm just going to merge this PR right now, because workflows can't be tested without deploying, and maybe it'll take many iterations to get this working.