### PR TITLE
Adjust wording; lowercase the first letter of datetime string

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentDeletedMetadata.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentDeletedMetadata.tsx
@@ -27,9 +27,9 @@ const CommentDeletedMetadata = ({documentId, classes}: {
     return (
       <div className={classes.root}>
         <div className={classes.meta}>
-          {deletedByUsername && <span>Deleted by {deletedByUsername}</span>}, {document.deletedDate && <span>
-            <Components.CalendarDate date={document.deletedDate}/>
-          </span>} 
+          Deleted {deletedByUsername && <span>by {deletedByUsername},</span>} {document.deletedDate && <span>
+            <Components.CalendarDate date={document.deletedDate} capitalizeFirstLetter={false} />
+          </span>}
         </div>
         {document.deletedReason &&
           <div className={classes.meta}>

--- a/packages/lesswrong/components/common/CalendarDate.tsx
+++ b/packages/lesswrong/components/common/CalendarDate.tsx
@@ -6,11 +6,14 @@ import { useTimezone } from '../common/withTimezone';
 /// A date rendered with moment().calendar(). Includes a plethora of special
 /// cases like "Yesterday at 1:00 PM", "Last Tuesday at 1:00 PM". Turns into a
 /// more normal date (in locale format) if more than a week away.
-const CalendarDate = ({date}: {
+const CalendarDate = ({date, capitalizeFirstLetter = true}: {
   date: Date,
+  capitalizeFirstLetter?: boolean;
 }) => {
   const { timezone } = useTimezone();
-  return <span>{moment(new Date(date)).tz(timezone).calendar()}</span>
+  const calendarDate = moment(new Date(date)).tz(timezone).calendar();
+  const displayDate = capitalizeFirstLetter ? calendarDate : calendarDate[0].toLowerCase() + calendarDate.slice(1);
+  return <span>{displayDate}</span>
 };
 
 const CalendarDateComponent = registerComponent('CalendarDate', CalendarDate);

--- a/packages/lesswrong/components/dropdowns/comments/DeleteCommentDialog.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/DeleteCommentDialog.tsx
@@ -68,10 +68,7 @@ const DeleteCommentDialog = ({comment, onClose, classes}: {
         </DialogTitle>
         <DialogContent>
           <p className={classes.subtitle}>
-            This comment will be marked as deleted and the username will become Anonymous.
-          </p>
-          <p className={classes.subtitle}>
-            You can add a reason for deleting it, if you want.
+          This comment will be marked as deleted. You can add a reason for deleting it, if you want.
           </p>
           <br/>
           <TextField


### PR DESCRIPTION
As discussed in the comments of [this ClickUp task](https://app.clickup.com/t/8685rfw6f), this PR adjusts the wording of the deletion modal, makes the deleted comment placeholder make sense whether the user has access to see the deleter or not, and makes the first character of the datetime string lower case.