### PR TITLE
Remove karma when listing users for mentions

### DIFF
--- a/packages/lesswrong/components/search/UsersSearchAutocompleteHit.tsx
+++ b/packages/lesswrong/components/search/UsersSearchAutocompleteHit.tsx
@@ -32,9 +32,6 @@ const UsersSearchAutocompleteHit = (props: UsersSearchAutocompleteHitProps) => {
     <MetaInfo className={metaClassName}>
       <FormatDate date={props.createdAt} tooltip={false} />
     </MetaInfo>
-    <MetaInfo className={metaClassName}>
-      {props.karma || 0} karma
-    </MetaInfo>
   </span>
 }
 


### PR DESCRIPTION
Easy three-line deletion to remove karma from the autosearch listing that comes up when @mentioning people in posts. Here's [the ClickUp task](https://app.clickup.com/t/868666tjz).