### PR TITLE
Remove `karma` from dynamic search results UI

### DIFF
--- a/packages/lesswrong/components/search/CommentsSearchHit.tsx
+++ b/packages/lesswrong/components/search/CommentsSearchHit.tsx
@@ -33,7 +33,7 @@ const isLeftClick = (event: React.MouseEvent): boolean => {
   return event.button === 0 && !event.ctrlKey && !event.metaKey;
 }
 
-const CommentsSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHitComponentProps) => {
+const CommentsSearchHit = ({hit, clickAction, classes, showIcon=false, showKarma=false}: SearchHitComponentProps) => {
   const comment = (hit as AlgoliaComment);
   const { LWTooltip } = Components
 
@@ -56,7 +56,7 @@ const CommentsSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHi
     <Link to={url} onClick={(event: React.MouseEvent) => isLeftClick(event) && clickAction && clickAction()}>
       <div>
         <Components.MetaInfo>{comment.authorDisplayName}</Components.MetaInfo>
-        <Components.MetaInfo>{comment.baseScore} karma </Components.MetaInfo>
+        {showKarma && <Components.MetaInfo>{comment.baseScore} karma </Components.MetaInfo>}
         <Components.MetaInfo>
           <Components.FormatDate date={comment.postedAt}/>
         </Components.MetaInfo>

--- a/packages/lesswrong/components/search/PostsSearchHit.tsx
+++ b/packages/lesswrong/components/search/PostsSearchHit.tsx
@@ -36,7 +36,7 @@ const isLeftClick = (event: React.MouseEvent): boolean => {
   return event.button === 0 && !event.ctrlKey && !event.metaKey;
 }
 
-const PostsSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHitComponentProps) => {
+const PostsSearchHit = ({hit, clickAction, classes, showIcon=false, showKarma=false}: SearchHitComponentProps) => {
   const post = (hit as AlgoliaPost);
   const { Typography, LWTooltip } = Components;
 
@@ -57,9 +57,9 @@ const PostsSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHitCo
           {post.authorDisplayName && <Components.MetaInfo>
             {post.authorDisplayName}
           </Components.MetaInfo>}
-          <Components.MetaInfo>
+          {showKarma && <Components.MetaInfo>
             {post.baseScore} karma
-          </Components.MetaInfo>
+          </Components.MetaInfo>}
           {post.postedAt && <Components.MetaInfo>
             <Components.FormatDate date={post.postedAt}/>
           </Components.MetaInfo>}

--- a/packages/lesswrong/components/search/UsersSearchHit.tsx
+++ b/packages/lesswrong/components/search/UsersSearchHit.tsx
@@ -25,7 +25,7 @@ const isLeftClick = (event: React.MouseEvent): boolean => {
   return event.button === 0 && !event.ctrlKey && !event.metaKey;
 }
 
-const UsersSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHitComponentProps) => {
+const UsersSearchHit = ({hit, clickAction, classes, showIcon=false, showKarma=false}: SearchHitComponentProps) => {
   const { LWTooltip, MetaInfo, FormatDate } = Components
   const user = hit as AlgoliaUser
 
@@ -40,9 +40,9 @@ const UsersSearchHit = ({hit, clickAction, classes, showIcon=false}: SearchHitCo
       <MetaInfo>
         <FormatDate date={user.createdAt} />
       </MetaInfo>
-      <MetaInfo>
+      {showKarma && <MetaInfo>
         {user.karma||0} karma
-      </MetaInfo>
+      </MetaInfo>}
     </Link>
   </div>
 }

--- a/packages/lesswrong/components/search/types.ts
+++ b/packages/lesswrong/components/search/types.ts
@@ -5,4 +5,5 @@ export type SearchHitComponentProps = {
   clickAction?: any,
   classes: ClassesType,
   showIcon?: boolean
+  showKarma?: boolean
 }


### PR DESCRIPTION
Adds a setting to search hits to hide karma and disables it by default for Users, Posts, Comments