### PR TITLE
Implement verifyEmailsSetting to skip verifying emails

### DIFF
--- a/packages/lesswrong/lib/collections/users/helpers.tsx
+++ b/packages/lesswrong/lib/collections/users/helpers.tsx
@@ -1,6 +1,6 @@
 import bowser from 'bowser';
 import { isClient, isServer } from '../../executionEnvironment';
-import { forumTypeSetting, isEAForum, isLW, lowKarmaUserVotingCutoffDateSetting, lowKarmaUserVotingCutoffKarmaSetting } from "../../instanceSettings";
+import { forumTypeSetting, isEAForum, isLW, lowKarmaUserVotingCutoffDateSetting, lowKarmaUserVotingCutoffKarmaSetting, verifyEmailsSetting } from "../../instanceSettings";
 import { getSiteUrl } from '../../vulcan-lib/utils';
 import { userOwns, userCanDo, userIsMemberOf } from '../../vulcan-users/permissions';
 import React, { useEffect, useState } from 'react';
@@ -280,7 +280,7 @@ export const userBlockedCommentingReason = (user: UsersCurrent|DbUser|null, post
 // Return true if the user's account has at least one verified email address.
 export const userEmailAddressIsVerified = (user: UsersCurrent|DbUser|null): boolean => {
   // EA Forum does not do its own email verification
-  if (forumTypeSetting.get() === 'EAForum') {
+  if (!verifyEmailsSetting.get()) {
     return true
   }
   if (!user || !user.emails)

--- a/packages/lesswrong/lib/instanceSettings.ts
+++ b/packages/lesswrong/lib/instanceSettings.ts
@@ -208,3 +208,5 @@ export const sortNewNameSetting = new PublicInstanceSetting<string | null>('sort
 export const sortOldNameSetting = new PublicInstanceSetting<string | null>('sortOldName', null, "optional");
 export const sortRecentRepliesNameSetting = new PublicInstanceSetting<string | null>('sortRecentRepliesName', null, "optional");
 export const sortRecentCommentsNameSetting = new PublicInstanceSetting<string | null>('sortRecentCommentsName', null, "optional");
+
+export const verifyEmailsSetting = new PublicInstanceSetting<boolean>("verifyEmails", true, "optional");

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -150,11 +150,6 @@ export const showCuratedSetting = new DatabasePublicSetting<boolean>("showCurate
 /** TODO; doc */
 export const showCommunityMapSetting = new DatabasePublicSetting<boolean>("showCommunityMap", false);
 
-// TODO: make this an instance setting if JP confirms that makes sense, because
-// we'd need it in collections/users/schema and server/emails/renderEmail
-/** whether this forum verifies user emails */
-export const verifyEmailsSetting = new DatabasePublicSetting<boolean>("verifyEmails", true);
-
 // TODO: make this an instance setting if JP confirms that makes sense
 // /** main theme color, needed here for server/emails/renderEmail */
 // export const mainThemeColorSetting = new DatabasePublicSetting<string>("mainThemeColor", "#5f9b65");

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -12,8 +12,8 @@ import { getCollectionHooks, UpdateCallbackProperties } from '../mutationCallbac
 import { voteCallbacks, VoteDocTuple } from '../../lib/voting/vote';
 import { encodeIntlError } from '../../lib/vulcan-lib/utils';
 import { sendVerificationEmail } from "../vulcan-lib/apollo-server/authentication";
-import {forumTypeSetting, isEAForum, isLW, isWakingUp } from "../../lib/instanceSettings";
-import { hasDigestSetting, mailchimpEAForumListIdSetting, mailchimpForumDigestListIdSetting, sendgridDigestListIdSetting, sendgridWelcomeListIdSetting, verifyEmailsSetting } from "../../lib/publicSettings";
+import {forumTypeSetting, isEAForum, isLW, isWakingUp, verifyEmailsSetting } from "../../lib/instanceSettings";
+import { hasDigestSetting, mailchimpEAForumListIdSetting, mailchimpForumDigestListIdSetting, sendgridDigestListIdSetting, sendgridWelcomeListIdSetting } from "../../lib/publicSettings";
 import { mailchimpAPIKeySetting } from "../../server/serverSettings";
 import {userGetLocation, getUserEmail} from "../../lib/collections/users/helpers";
 import { captureException } from "@sentry/core";


### PR DESCRIPTION
I had thought I'd made a PR for this a few days ago, but apparently not. This adds an instance setting to determine whether email verification is required. It solves [this ClickUp task](https://app.clickup.com/t/8686348vw).