### PR TITLE
Implement RateLimitError

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/errors.ts
+++ b/packages/lesswrong/lib/vulcan-lib/errors.ts
@@ -171,7 +171,14 @@ export const AuthorizationError = createError(
   }
 )
 
-const whitelistedErrors = ["SimpleValidationError", "AuthorizationError"]
+export const RateLimitError = createError(
+  'RateLimitError',
+  {
+    message: "You can't do that again yet.",
+  }
+)
+
+const whitelistedErrors = ["SimpleValidationError", "AuthorizationError", "RateLimitError"]
 
 // Most errors shouldn't be shown to the user. Only a few specific ones should,
 // and they're whitelisted here.

--- a/packages/lesswrong/server/callbacks/rateLimitCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/rateLimitCallbacks.ts
@@ -4,6 +4,7 @@ import Users from '../../lib/collections/users/collection';
 import { getCollectionHooks } from '../mutationCallbacks';
 import { rateLimitDateWhenUserNextAbleToComment, rateLimitDateWhenUserNextAbleToPost } from '../rateLimitUtils';
 import { interpolateRateLimitMessage } from '../../lib/rateLimits/utils';
+import { RateLimitError } from '../vulcan-lib';
 
 // Post rate limiting
 getCollectionHooks("Posts").createValidate.add(async function PostsNewRateLimit (validationErrors, { newDocument: post, currentUser }) {
@@ -87,7 +88,7 @@ async function enforceCommentRateLimit({user, comment, context}:{
         interpolateRateLimitMessage(rateLimit.rateLimitMessage, nextEligible) :
         `Rate limit: You cannot comment for ${moment(nextEligible).fromNow()} (until ${nextEligible})`
 
-      throw new Error(message);
+      throw new RateLimitError({message: message})
     }
   }
 }


### PR DESCRIPTION
This PR adds the new whitelisted RateLimitError (whitelisted for users to see) to fix the problem mentioned in the comments at [this ClickUp task](https://app.clickup.com/t/8685g0hva), where the generic error message ("Something went wrong...") appears for rate limit errors, rather than the rate limit error (e.g. "Please wait 5 seconds before commenting again.").