### PR TITLE
Adjust items of post and comment action menus

### DIFF
--- a/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
@@ -59,8 +59,8 @@ const CommentActions = ({currentUser, comment, post, tag, showEdit}: {
       <PinToProfileDropdownItem comment={comment} post={post} />
       <NotifyMeDropdownItem
         document={comment}
-        subscribeMessage="Subscribe to comment replies"
-        unsubscribeMessage="Unsubscribe from comment replies"
+        subscribeMessage="Subscribe to Comment Replies"
+        unsubscribeMessage="Unsubscribe from Comment Replies"
       />
       {!currentUserIsAuthor && <ReportCommentDropdownItem comment={comment} post={post} />}
       <MoveToAlignmentCommentDropdownItem comment={comment} post={postDetails} />

--- a/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
@@ -58,11 +58,11 @@ const PostActions = ({post, closeMenu, includeBookmark=true, classes}: {
       {isBookUI && shareButtonSetting.get() && <SharePostSubmenu post={post} closeMenu={closeMenu} />}
       <DuplicateEventDropdownItem post={post} />
       <PostAnalyticsDropdownItem post={post} />
-      {currentUserIsAuthor && <NotifyMeDropdownItem
+      <NotifyMeDropdownItem
         document={post}
-        subscribeMessage="Subscribe to comments"
-        unsubscribeMessage="Unsubscribe from comments"
-      />}
+        subscribeMessage="Subscribe to Comments"
+        unsubscribeMessage="Unsubscribe from Comments"
+      />
       {!currentUserIsAuthor && includeBookmark && <BookmarkDropdownItem post={post} />}
       {!currentUserIsAuthor && <ReportPostDropdownItem post={post}/>}
       {/* Tags (topics) are removed for launch, but will be added back later, so I'm leaving this commented out. */}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPagePostHeader.tsx
@@ -7,7 +7,7 @@ import { getUrlClass } from '../../../lib/routeUtil';
 import classNames from 'classnames';
 import { isServer } from '../../../lib/executionEnvironment';
 import moment from 'moment';
-import { shareButtonSetting, isLWorAF } from '../../../lib/instanceSettings';
+import { shareButtonSetting, isLWorAF, isEAForum } from '../../../lib/instanceSettings';
 import { useCookiesWithConsent } from '../../hooks/useCookiesWithConsent';
 import { PODCAST_TOOLTIP_SEEN_COOKIE } from '../../../lib/cookies/cookies';
 import { isBookUI, isFriendlyUI } from '../../../themes/forumTheme';
@@ -337,7 +337,7 @@ const PostsPagePostHeader = ({post, answers = [], dialogueResponses = [], showEm
   const tripleDotMenuNode = !hideMenu &&
     <span className={classes.actions}>
       <AnalyticsContext pageElementContext="tripleDotMenu">
-        <PostActionsButton post={post} includeBookmark={isBookUI} flip={true}/>
+        <PostActionsButton post={post} includeBookmark={!isEAForum} flip={true}/>
       </AnalyticsContext>
     </span>
 


### PR DESCRIPTION
As mentioned in the comments of [this ClickUp task](https://app.clickup.com/t/8685rfd6p), these are a few updates to post and comment menus. It makes non-authors able to subscribe to post comments, changes some capitalization, and adds the Save item to the dropdown menu.