### PR TITLE
Don't restrict viewing posts by unreviewed users

### DIFF
--- a/packages/lesswrong/lib/collections/posts/permissions.ts
+++ b/packages/lesswrong/lib/collections/posts/permissions.ts
@@ -53,11 +53,6 @@ Posts.checkAccess = async (currentUser: DbUser|null, post: DbPost, context: Reso
     return true;
   } else if (post.isFuture || post.draft || post.deletedDraft) {
     return false;
-    // TODO: consider getting rid of this clause entirely and instead just relying on default view filter, 
-    // since LW is now allowing people to see rejected content and preventing them from seeing 'not-yet-rejected
-    // content is kinda weird)
-  } else if (post.authorIsUnreviewed && !post.rejected) {
-    return false
   } else {
     const status = _.findWhere(postStatusLabels, {value: post.status});
     if (!status) return false;


### PR DESCRIPTION
Posts by unreviewed users weren't appearing on the front page (despite me having thought I'd enabled this in [an earlier PR](https://github.com/wakingupllc/wakingup-community/pull/18)). Turns out that admins could see new posts, but they were still hidden for non-admins. This PR solves that.