### PR TITLE
Add GitHub workflow to automatically deploy to production

### DIFF
--- a/.github/workflows/deployWUProd.yml
+++ b/.github/workflows/deployWUProd.yml
@@ -1,0 +1,35 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Deploy WU Prod
+concurrency: deploy-wu-prod
+on:
+  push:
+    branches: [ wu-deploy ]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+        environment: [WakingUpCommunity-env]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '>=3.5' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+    - run: pip3 install "pyyaml<5.4" && pip3 install --upgrade pip awsebcli # pip3 install "pyyaml<5.4" is a temporary workaround for this bug: https://github.com/aws/aws-elastic-beanstalk-cli/issues/441
+    - name: Run Migrations
+      if: github.ref == 'refs/heads/wu-deploy'
+      uses: ./.github/actions/runMigrations
+      with:
+        mode: prod
+        credentials-repo: ${{ secrets.WU_CREDENTIALS_REPO }}
+        credentials-pat: ${{ secrets.WU_CREDENTIALS_PAT }}
+        transcrypt-secret: ${{ secrets.WU_TRANSCRYPT_SECRET }}
+    - name: Run Deploy
+      run: scripts/deploy.sh "Waking Up Community" ${{ matrix.environment }}
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.WU_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.WU_AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: "us-west-2"


### PR DESCRIPTION
This workflow will automatically deploy the code in the wu-deploy branch.

(Though, it won't actually succeed yet, because .elasticbeanstalk/config.yml's default_region is us-east-1, but the production server is on us-west-2. I could make this configurable, but Jose says I should move the staging server to us-west-2 anyway, so I'll just do that, probably tomorrow evening.)