### PR TITLE
Add WakingUp forumDomainWhitelist to discern onsite links

### DIFF
--- a/packages/lesswrong/lib/routeUtil.tsx
+++ b/packages/lesswrong/lib/routeUtil.tsx
@@ -145,6 +145,14 @@ const forumDomainWhitelist: ForumOptions<DomainList> = {
     ],
     mirrorDomains: ['ea.greaterwrong.com'],
   },
+  WakingUp: {
+    onsiteDomains: [
+      'community.wakingup.com',
+      'community.staging.wakingup.com',
+      `localhost:${getServerPort()}`,
+    ],
+    mirrorDomains: [],
+  },
   default: {
     onsiteDomains: [
       `localhost:${getServerPort()}`,


### PR DESCRIPTION
When a post is submitted, all its links are scanned to check whether they're on-site or off-site links. If they're on-site links, they're checked to see if they're a user mention. This PR adds WakingUp-specific forumSelect values so we can detect whether links are on-site. (This should be a setting, but there's no good default that would work for the other sites, so implementing it as a setting would require coordination with the other site teams, which I'd rather not attempt this week. I've added it to my list of things to coordinate with the other site teams.)

[Here's the relevant ClickUp task](https://app.clickup.com/t/8686bx47m).