### PR TITLE
Fix rate limit warning when editing posts; fix RateLimitError

### DIFF
--- a/packages/lesswrong/components/posts/PostsEditForm.tsx
+++ b/packages/lesswrong/components/posts/PostsEditForm.tsx
@@ -114,7 +114,7 @@ const PostsEditForm = ({ documentId, classes }: {
       <div className={classes.postForm}>
         <HeadTags title={document.title} />
         {currentUser && <Components.PostsAcceptTos currentUser={currentUser} />}
-        {rateLimitNextAbleToPost && <RateLimitWarning lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible} rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}  />}
+        {document.draft && rateLimitNextAbleToPost && <RateLimitWarning lastRateLimitExpiry={rateLimitNextAbleToPost.nextEligible} rateLimitMessage={rateLimitNextAbleToPost.rateLimitMessage}  />}
         <NoSSR>
           <WrappedSmartForm
             collectionName="Posts"

--- a/packages/lesswrong/server/callbacks/rateLimitCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/rateLimitCallbacks.ts
@@ -66,7 +66,7 @@ async function enforcePostRateLimit (user: DbUser) {
         interpolateRateLimitMessage(rateLimit.rateLimitMessage, nextEligible) :
         `Rate limit: You cannot post for ${moment(nextEligible).fromNow()} (until ${nextEligible})`
 
-      throw new Error(message);
+      throw new RateLimitError({message: message})
     }
   }
 }


### PR DESCRIPTION
This PR prevents rate limit warnings appearing when you're editing a published post. (I'm confused about why the upstream code is like this, though it's not the only upstream rate limit bug, so maybe it just doesn't come up much.)

Contrary to what the [associated ClickUp task](https://app.clickup.com/t/8686bru78) says, the warning doesn't prevent you editing a published post, but it does mean you won't be able to edit and then publish a draft post. Hopefully that's the case that Jeremy tried.

This PR also fixes the error message that occurs if you try to submit the post; it was the generic one, not a whitelisted RateLimitError one.