### PR TITLE
Prevent share intent modal appearing on copy link buttons

### DIFF
--- a/packages/lesswrong/components/dropdowns/posts/SharePostSubmenu.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/SharePostSubmenu.tsx
@@ -35,7 +35,7 @@ const SharePostSubmenu = ({post, closeMenu, classes}: {
     }
   }
   
-  const hasSubmenu = isServer || !navigator.canShare;
+  const hasSubmenu = !shareButtonSetting.get() || isServer || !navigator.canShare;
   const MaybeWrapWithSubmenu = hasSubmenu
     ? ({children}: {children: React.ReactNode}) => <LWTooltip
         title={<SharePostActions post={post} onClick={closeMenu} />}


### PR DESCRIPTION
This PR solves the strange behavior where the Copy Link button opened a share modal on Windows and some other platforms. (Turns out it wasn't just calling navigator.clipboard; it was also calling navigator.share.) [Here's the ClickUp task](https://app.clickup.com/t/8686b6afj).