### PR TITLE
SendGrid emails use a pretty from name

### DIFF
--- a/packages/lesswrong/server/emails/sendEmail.ts
+++ b/packages/lesswrong/server/emails/sendEmail.ts
@@ -149,7 +149,9 @@ export const sendEmailSendgridTemplate = async (emailData: SendgridEmailData) =>
         ]
       }
     ],
-    from: {email: fromAddress},
+    // Currently hard-coded - this is the only allowed from address on Sendgrid,
+    // with the only allowed name
+    from: {name: "Waking Up Community", email: fromAddress},
     ...mailSettings
   }
   client


### PR DESCRIPTION
Fixes an issue brought up in QA [here](https://app.clickup.com/t/8685a41vn?comment=90110025604601&threadedComment=90110025783224). It appears that SendGrid will not automatically use the name you've set to your verified email address.