### PR TITLE
Change forumType to WakingUp in the schemacheck unit test

### DIFF
--- a/packages/lesswrong/unitTests/schemacheck.test.ts
+++ b/packages/lesswrong/unitTests/schemacheck.test.ts
@@ -12,7 +12,7 @@ describe('Schema check', () => {
       writeAcceptedSchema: true,
       generateMigrations: false,
       rootPath,
-      forumType: "EAForum",
+      forumType: "WakingUp",
       silent: true,
     });
   }, 60000);


### PR DESCRIPTION
The database hash-checking unit tests have been failing because the database gets hashed differently based on forum type. This PR fixes that.