### PR TITLE
Stop users seeing their deleted posts; mark deleted posts as [Deleted]

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -387,7 +387,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
           {moderatedCommentId === comment._id && <FlagIcon className={classes.flagIcon} />}
           {showPostTitle && !isChild && hasPostField(comment) && comment.post && <LWTooltip tooltip={false} title={<PostsPreviewTooltipSingle postId={comment.postId}/>}>
               <Link className={classes.postTitle} to={commentGetPageUrlFromIds({postId: comment.postId, commentId: comment._id, postSlug: ""})}>
-                {comment.post.draft && "[Draft] "}
+                {comment.post.draft && (comment.post.deletedDraft ? "[Deleted] " : "[Draft] ")}
                 {comment.post.title}
               </Link>
             </LWTooltip>}

--- a/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPageTitle.tsx
@@ -79,7 +79,9 @@ const PostsPageTitle = ({classes, post}: {
       </Typography>}
       <Typography variant="display3" className={classes.root}>
         <Link to={postGetPageUrl(post)} className={classes.link}>
-          {post.draft && <span className={classes.draft}>[Draft] </span>}
+          {post.draft && <span className={classes.draft}>
+          {post.deletedDraft ? <>[Deleted] </> : <>[Draft] </>}
+          </span>}
           {mostOfTitle}{mostOfTitle && " "}
           <span className={classes.lastWord}>
             {lastWordOfTitle}

--- a/packages/lesswrong/components/posts/PostsTitle.tsx
+++ b/packages/lesswrong/components/posts/PostsTitle.tsx
@@ -171,7 +171,9 @@ const PostsTitle = ({
     </span>}
     {Icon && <Icon className={classes.primaryIcon}/>}
 
-    {post.draft && showDraftTag && <span className={classes.tag}>[Draft]</span>}
+    {post.draft && showDraftTag && <span className={classes.tag}>
+      {post.deletedDraft ? <>[Deleted]</> : <>[Draft]</>}
+    </span>}
     {post.isFuture && <span className={classes.tag}>[Pending]</span>}
     {post.unlisted && <span className={classes.tag}>[Unlisted]</span>}
     {shared && <span className={classes.tag}>[Shared]</span>}

--- a/packages/lesswrong/lib/collections/posts/fragments.ts
+++ b/packages/lesswrong/lib/collections/posts/fragments.ts
@@ -8,6 +8,7 @@ registerFragment(`
     slug
     title
     draft
+    deletedDraft
     shortform
     hideCommentKarma
     af

--- a/packages/lesswrong/lib/collections/posts/permissions.ts
+++ b/packages/lesswrong/lib/collections/posts/permissions.ts
@@ -47,7 +47,8 @@ Posts.checkAccess = async (currentUser: DbUser|null, post: DbPost, context: Reso
   }
   if (userCanDo(currentUser, 'posts.view.all')) {
     return true
-  } else if (userOwns(currentUser, post) || userIsSharedOn(currentUser, post) || await userIsPostGroupOrganizer(currentUser, post, context)) {
+    // Unlike other forums, WakingUp doesn't allow owners to see their deletedDraft posts
+  } else if (!post.deletedDraft && (userOwns(currentUser, post) || userIsSharedOn(currentUser, post) || await userIsPostGroupOrganizer(currentUser, post, context))) {
     return true;
   } else if (!currentUser && !!canonicalLinkSharingKey && constantTimeCompare({ correctValue: canonicalLinkSharingKey, unknownValue: unvalidatedLinkSharingKey })) {
     return true;

--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -2404,7 +2404,7 @@ const schema: SchemaType<DbPost> = {
       type: 'Boolean',
       resolver: async (post: DbPost, args: void, context: ResolverContext): Promise<boolean> => {
         const { LWEvents, currentUser } = context;
-        if(currentUser){
+        if(currentUser && !post.deletedDraft){
           const query = {
             name:'toggled-user-moderation-guidelines',
             documentId: post.userId,

--- a/packages/lesswrong/lib/generated/fragmentTypes.d.ts
+++ b/packages/lesswrong/lib/generated/fragmentTypes.d.ts
@@ -906,6 +906,7 @@ interface PostsMinimumInfo { // fragment on Posts
   readonly slug: string,
   readonly title: string,
   readonly draft: boolean,
+  readonly deletedDraft: boolean,
   readonly shortform: boolean,
   readonly hideCommentKarma: boolean,
   readonly af: boolean,

--- a/packages/lesswrong/lib/vulcan-users/permissions.ts
+++ b/packages/lesswrong/lib/vulcan-users/permissions.ts
@@ -125,6 +125,16 @@ export const userOwnsAndOnLW = function (user:UsersMinimumInfo|DbUser|null, docu
   return isLW && userOwns(user, document)
 }
 
+const documentDeleted = (document: OwnableDocument) => {
+  // Unfortunately, different collections use different field names
+  // to represent "deleted-ness"
+  return (
+    (document as unknown as DbComment).deleted ||
+    (document as unknown as DbPost).deletedDraft ||
+    (document as unknown as DbSequence).isDeleted
+  );
+}
+
 export const documentIsNotDeleted = (
   user: PermissionableUser|DbUser|null,
   document: OwnableDocument,
@@ -134,16 +144,11 @@ export const documentIsNotDeleted = (
     return true;
   }
   // Authors can see their deleted content
-  if (userOwns(user, document)) {
+  if (userOwns(user, document) && !documentDeleted(document)) {
     return true;
   }
-  // Unfortunately, different collections use different field names
-  // to represent "deleted-ness"
-  return !(
-    (document as unknown as DbComment).deleted ||
-    (document as unknown as DbPost).deletedDraft ||
-    (document as unknown as DbSequence).isDeleted
-  );
+
+  return !documentDeleted(document);
 }
 
 export const userCanComment = (user: PermissionableUser|DbUser|null): boolean => {


### PR DESCRIPTION
Upstream, users can still see their deleted posts. There's no link to them in their profile, but if they happen to know the URL, they can still view them (as can admins).

This PR removes permission from users seeing their own posts.

Admins can still see deleted posts. They weren't distinguishable from drafts, because they'd be marked "[Draft]". Now they're marked "[Deleted]".

[Here's the ClickUp task](https://app.clickup.com/t/8686d3qam).