### PR TITLE
Remove Version History button from CKEditor

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -17,6 +17,7 @@ import Transition from 'react-transition-group/Transition';
 import { useTracking } from '../../lib/analyticsEvents';
 import { PostCategory } from '../../lib/collections/posts/helpers';
 import { DynamicTableOfContentsContext } from '../posts/TableOfContents/DynamicTableOfContents';
+import { showVersionHistorySetting } from '../../lib/publicSettings';
 
 const autosaveInterval = 3000; //milliseconds
 
@@ -358,7 +359,7 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
       maxHeight={maxHeight}
       hasCommitMessages={hasCommitMessages ?? undefined}
     />
-    {!hideControls && collectionName==="Posts" && fieldName==="contents" && !!document._id &&
+    {showVersionHistorySetting.get() && !hideControls && collectionName==="Posts" && fieldName==="contents" && !!document._id &&
       <Components.PostVersionHistoryButton
         post={document}
         postId={document._id}

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -174,3 +174,4 @@ export const requireMarkdownOnMobileSetting = new DatabasePublicSetting<boolean>
 export const wuDefaultProfileImageCloudinaryIdSetting = new DatabasePublicSetting<string>('wuDefaultProfileImageCloudinaryId', "default_profile_image_thumb_x1_ajlf63");
 export const onetrustDomainScriptSetting = new DatabasePublicSetting<string>('onetrustDomainScript', "c8afa025-de60-4850-a9db-4962e99aa987-test");
 export const notificationBatchHourInUserTzSetting = new DatabasePublicSetting<number>('notificationBatchHourInUserTz', 17)
+export const showVersionHistorySetting = new DatabasePublicSetting<boolean>('showVersionHistory', true);


### PR DESCRIPTION
Tiny PR to remove the Version History button from the bottom left of the CKEditor. [Here's the ClickUp task](https://app.clickup.com/t/8686d3j85).