### PR TITLE
Fix font and margin of cookie banner

### DIFF
--- a/packages/lesswrong/themes/globalStyles/miscStyles.ts
+++ b/packages/lesswrong/themes/globalStyles/miscStyles.ts
@@ -273,4 +273,17 @@ div#mocha {
      has an ill-advised max-width:none in it. */
   max-width: 100% !important;
 }
+
+/*
+ * OneTrust cookie consent banner
+ */
+
+#onetrust-consent-sdk {
+  font-family: GreekFallback,Inter,Helvetica Neue,Helvetica,Arial,sans-serif;
+}
+
+#onetrust-consent-sdk #onetrust-banner-sdk.ot-wo-title #onetrust-group-container {
+  margin-top: 0;
+}
+
 `


### PR DESCRIPTION
This PR changes the serif font to our usual font stack, and removes the too-tall top margin, of the cookie banner.

How it was:

<img width="416" alt="Screenshot 2023-11-14 at 9 29 22 AM" src="https://github.com/wakingupllc/wakingup-community/assets/675520/c6a7160d-dc40-4269-a059-e0bfee081ba7">

How it is with this PR:

<img width="412" alt="Screenshot 2023-11-14 at 9 29 29 AM" src="https://github.com/wakingupllc/wakingup-community/assets/675520/21c274dd-01eb-4c0c-bc9d-9a1193d79f82">

Then we'll be consistent with the banner at wakingup.com, though with a better top margin:

<img width="427" alt="Screenshot 2023-11-14 at 9 29 48 AM" src="https://github.com/wakingupllc/wakingup-community/assets/675520/9ea2efad-e7c9-400c-b313-4bc971ecb80e">
