### PR TITLE
Always show comment permalinks in place (not above post)

### DIFF
--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -7,6 +7,7 @@ import { AnalyticsContext, useTracking } from "../../lib/analyticsEvents"
 import { CommentTreeNode, commentTreesEqual } from '../../lib/utils/unflatten';
 import type { CommentTreeOptions } from './commentTree';
 import { HIGHLIGHT_DURATION } from './CommentFrame';
+import { commentPermalinksAtTopSetting } from '../../lib/publicSettings';
 
 const KARMA_COLLAPSE_THRESHOLD = -4;
 
@@ -115,6 +116,7 @@ const CommentsNode = ({
   const [collapsed, setCollapsed] = useState(!forceUnCollapsed && (comment.deleted || comment.baseScore < karmaCollapseThreshold || comment.modGPTRecommendation === 'Intervene'));
   const [truncatedState, setTruncated] = useState(!!startThreadTruncated);
   const { lastCommentId, condensed, postPage, post, highlightDate, scrollOnExpand, forceSingleLine, forceNotSingleLine, noHash, onToggleCollapsed } = treeOptions;
+  const location = useSubscribedLocation();
 
   const beginSingleLine = (): boolean => {
     // TODO: Before hookification, this got nestingLevel without the default value applied, which may have changed its behavior?
@@ -175,7 +177,9 @@ const CommentsNode = ({
 
   const {hash: commentHash} = useSubscribedLocation();
   useEffect(() => {
-    if (!noHash && !noAutoScroll && comment && commentHash === ("#" + comment._id)) {
+    const hashCommentLink = !noHash && !noAutoScroll && comment && commentHash === ("#" + comment._id)
+    const commentPermalinkInPlace = !commentPermalinksAtTopSetting.get() && [location.query.commentId, location.params.commentId].includes(comment._id)
+    if (hashCommentLink || commentPermalinkInPlace) {
       setTimeout(() => { //setTimeout make sure we execute this after the element has properly rendered
         void handleExpand()
         scrollIntoView()

--- a/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPage.tsx
@@ -8,7 +8,7 @@ import withErrorBoundary from '../../common/withErrorBoundary'
 import { useRecordPostView } from '../../hooks/useRecordPostView';
 import { AnalyticsContext, useTracking } from "../../../lib/analyticsEvents";
 import {forumTitleSetting, isAF, isEAForum} from '../../../lib/instanceSettings';
-import { cloudinaryCloudNameSetting, showTableOfContentsSetting } from '../../../lib/publicSettings';
+import { cloudinaryCloudNameSetting, commentPermalinksAtTopSetting, showTableOfContentsSetting } from '../../../lib/publicSettings';
 import classNames from 'classnames';
 import { userHasSideComments } from '../../../lib/betas';
 import { forumSelect } from '../../../lib/forumTypeUtils';
@@ -525,7 +525,7 @@ const PostsPage = ({post, eagerPostComments, refetch, classes}: {
     <AnalyticsContext pageSectionContext="postHeader">
       <div className={classes.title}>
         <div className={classes.centralColumn}>
-          {commentId && !isDebateResponseLink && <CommentPermalink documentId={commentId} post={post} />}
+          {commentPermalinksAtTopSetting.get() && commentId && !isDebateResponseLink && <CommentPermalink documentId={commentId} post={post} />}
           {post.eventImageId && <div className={classNames(classes.headerImageContainer, {[classes.headerImageContainerWithComment]: commentId})}>
             <CloudinaryImage2
               publicId={post.eventImageId}

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -175,3 +175,4 @@ export const wuDefaultProfileImageCloudinaryIdSetting = new DatabasePublicSettin
 export const onetrustDomainScriptSetting = new DatabasePublicSetting<string>('onetrustDomainScript', "c8afa025-de60-4850-a9db-4962e99aa987-test");
 export const notificationBatchHourInUserTzSetting = new DatabasePublicSetting<number>('notificationBatchHourInUserTz', 17)
 export const showVersionHistorySetting = new DatabasePublicSetting<boolean>('showVersionHistory', true);
+export const commentPermalinksAtTopSetting = new DatabasePublicSetting<boolean>('commentPermalinksAtTop', true);


### PR DESCRIPTION
[ClickUp task](https://app.clickup.com/t/8686drz9j).

There are two ways to make a comment permalink:
1. You can use a `commentId` parameter "?commentId=mn4Ziat2WAztXBHAy", like `https://community.staging.wakingup.com/posts/ooh5MzQjbFHshsDwj/welcome-to-the-waking-up-community-beta?commentId=mn4Ziat2WAztXBHAy`. These permalinks make the comment appear above the post.
2. You can just put the comment id after a hash, like `https://community.staging.wakingup.com/posts/ooh5MzQjbFHshsDwj/welcome-to-the-waking-up-community-beta#mn4Ziat2WAztXBHAy`. These permalinks only display the comment in place, and the page automatically scrolls to it and highlights it on load.

This change makes the first kind of permalink behave like the second kind. Comments no longer appear above the post; they only appear in place, scrolled to and highlighted.