### PR TITLE
Fix error in profanity filter when name is missing

### DIFF
--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -281,6 +281,8 @@ export type SocialMediaProfileField = keyof typeof SOCIAL_MEDIA_PROFILE_FIELDS;
 export type RateLimitReason = "moderator"|"lowKarma"|"downvoteRatio"|"universal"
 
 const validateName = (name: string, field: string) => {
+  if (!name) return;
+
   if (badWords.includes(name.toLowerCase().trim()) || badWords.includes(name.toLowerCase().replace(/[0-9]/g, "").trim())) {
     throwValidationError({
       typeName: "User",


### PR DESCRIPTION
Unit tests failed because the dummyUser lacked a displayName, and the profanity filter expected a displayName. Now the profanity function just returns if the name is missing.