### PR TITLE
Query Waking Up app endpoint with lowercased email address

### DIFF
--- a/packages/lesswrong/server/forumSpecificMiddleware/wuMiddleware.ts
+++ b/packages/lesswrong/server/forumSpecificMiddleware/wuMiddleware.ts
@@ -88,7 +88,8 @@ async function getWakingUpUserData(email: string): Promise<any> {
   const wakingUpKey = wakingUpKeySetting.get()
   const wakingUpEndpoint = wakingUpEndpointSetting.get()
 
-  const url = `${wakingUpEndpoint}${email}`;
+  // The Waking Up API expects email addresses to be in lowercase.
+  const url = `${wakingUpEndpoint}${email.toLowerCase()}`;
   const headers = {
     'x-community-key': wakingUpKey,
   };


### PR DESCRIPTION
The Waking Up app endpoint expects all emails to be lower-cased. Here's [the ClickUp task](https://app.clickup.com/t/8686eyvr1).