### PR TITLE
Fix Copy Link url, tooltip

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
@@ -227,6 +227,7 @@ export const CommentsItemMeta = ({
     postId: post!._id,
     postSlug: post!.slug,
     commentId: comment._id,
+    isAbsolute: true,
   });
 
   const copyLink = () => {

--- a/packages/lesswrong/components/posts/SharePostButton.tsx
+++ b/packages/lesswrong/components/posts/SharePostButton.tsx
@@ -71,7 +71,7 @@ const SharePostButton = ({
 
   return <div className={classes.root}>
     <div ref={anchorEl}>
-      <LWTooltip title="Share post" placement="bottom-start" disabled={isOpen}>
+      <LWTooltip title="Copy Link" placement="bottom-start" disabled={isOpen}>
         <ForumIcon
           icon="Link"
           className={classNames(classes.icon, className)}


### PR DESCRIPTION
argh I had neglected to properly check that commentGetPageUrlFromIds behaved as expected, and it gave relative URLs by default—not useful for copying a link for sharing. This PR fixes that, and also fixes a tooltip title, as required in a comment of [this ClickUp task](https://app.clickup.com/t/8686b6afj).