### PR TITLE
Reset login restrictions

### DIFF
--- a/packages/lesswrong/server/forumSpecificMiddleware/wuMiddleware.ts
+++ b/packages/lesswrong/server/forumSpecificMiddleware/wuMiddleware.ts
@@ -237,27 +237,17 @@ addGraphQLSchema(loginData);
 addGraphQLSchema(requestedCodeData);
 
 function updateUserLoginProps(user: DbUser, oneTimeCode: string|null, successfulLogin = false) {
-  const limitStartAt = codeRequestLimitActive(user) ?? new Date()
-  const otcRequests = (wuServ(user)?.otcRequests ?? 0) + 1
-
-  const loginFields = (() => {
-    if (successfulLogin) {
-      return {
-        otcRequests: 0,
-        otcEntryAttempts: 0,
-        otcEntryLockedAt: null,
-        codeRequestLimitStartAt: null
-      }
-    }
-    return {}
-  })()
-
-  const fieldUpdates = {
-    codeRequestLimitStartAt: limitStartAt,
+  const fieldUpdates = successfulLogin ? {
+    otcRequests: 0,
+    otcEntryAttempts: 0,
+    otcEntryLockedAt: null,
+    codeRequestLimitStartAt: null,
+    oneTimeCode: null,
+} : {
+    codeRequestLimitStartAt: codeRequestLimitActive(user) ?? new Date(),
+    otcRequests: (wuServ(user)?.otcRequests ?? 0) + 1,
     oneTimeCode,
-    otcRequests,
-    ...loginFields
-  }
+}
 
   return Users.rawUpdateOne(
     {_id: user._id},


### PR DESCRIPTION
I'd neglected to reset the login restriction variables on successful login. This PR fixes that, and removes the *@wakingup.com immunity to login restrictions.

Here's [the ClickUp task](https://app.clickup.com/t/8686eu2a8).