### PR TITLE
Default username

### DIFF
--- a/packages/lesswrong/lib/badWords.json
+++ b/packages/lesswrong/lib/badWords.json
@@ -216,6 +216,8 @@
   "mis",
   "mob",
   "mobile",
+  "moderator",
+  "moderation",
   "msg",
   "must",
   "mx",

--- a/packages/lesswrong/lib/collections/users/schema.ts
+++ b/packages/lesswrong/lib/collections/users/schema.ts
@@ -41,6 +41,10 @@ import badWords from '../../badWords.json';
 // Anything else..
 ///////////////////////////////////////
 
+export const usernameIsBadWord = (username: string) => {
+  return badWords.includes(username.toLowerCase().trim()) || badWords.includes(username.toLowerCase().replace(/[0-9]/g, "").trim())
+}
+
 const createDisplayName = (user: DbInsertion<DbUser>): string => {
   const profileName = getNestedProperty(user, 'profile.name');
   const twitterName = getNestedProperty(user, 'services.twitter.screenName');
@@ -283,7 +287,7 @@ export type RateLimitReason = "moderator"|"lowKarma"|"downvoteRatio"|"universal"
 const validateName = (name: string, field: string) => {
   if (!name) return;
 
-  if (badWords.includes(name.toLowerCase().trim()) || badWords.includes(name.toLowerCase().replace(/[0-9]/g, "").trim())) {
+  if (usernameIsBadWord(name)) {
     throwValidationError({
       typeName: "User",
       field,

--- a/packages/lesswrong/server/forumSpecificMiddleware/wuMiddleware.ts
+++ b/packages/lesswrong/server/forumSpecificMiddleware/wuMiddleware.ts
@@ -18,6 +18,7 @@ import {cloudinaryPublicIdFromUrl, moveToCloudinary} from '../scripts/convertIma
 import {devLoginsAllowedSetting, wuDefaultProfileImageCloudinaryIdSetting} from '../../lib/publicSettings.ts'
 import { sendEmailSendgridTemplate } from '../emails/sendEmail.ts'
 import moment from 'moment'
+import { usernameIsBadWord } from '../../lib/collections/users/schema.ts'
 
 const LOGIN_LIMIT_HOURS = 3
 const CODE_REQUEST_LIMIT = 5
@@ -212,7 +213,7 @@ const rehostProfileImageToCloudinary = async (url: string) => {
   return cloudinaryPublicIdFromUrl(newUrl, folder)
 }
 
-function wuDisplayName(wuUser: WuUserData): string {
+const defaultName = (wuUser: WuUserData): string => {
   if (wuUser.first_name && wuUser.last_name) {
     return `${wuUser.first_name} ${wuUser.last_name}`
   } else if (wuUser.first_name) {
@@ -221,6 +222,16 @@ function wuDisplayName(wuUser: WuUserData): string {
     return wuUser.last_name
   } else {
     return wuUser.email!.split('@')[0]
+  }
+}
+
+function wuDisplayName(wuUser: WuUserData): string {
+  const name = defaultName(wuUser)
+
+  if (usernameIsBadWord(name)) {
+    return 'newuser'
+  } else {
+    return name
   }
 }
 


### PR DESCRIPTION
This PR prevents default usernames being allocated that match the words from the badWords (profanity and misleading and Sam-related words) list. They fall back to "newuser" (you might worry that that'll cause duplicate usernames, but there's another process in user creation that appends "-n" (like "-2" or "-3" etc.) to duplicate usernames so that's fine.