### PR TITLE
Only show users in search if they completed onboarding

### DIFF
--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -177,6 +177,7 @@ export default class UsersRepo extends AbstractRepo<DbUser> {
         u."first_name" AS "firstName",
         u."last_name" AS "lastName",
         u."wu_created_at" AS "wuCreatedAt",
+        u."acceptedTos" AS "completedOnboarding",
         NOW() AS "exportedAt"
       FROM "Users" u
     `;

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -262,6 +262,7 @@ const elasticSearchConfig: Record<AlgoliaIndexCollectionName, IndexConfig> = {
     filters: [
       {range: {karma: {gte: 0}}},
       {term: {deleted: false}},
+      {term: {completedOnboarding: true}},
       {term: {deleteContent: false}},
     ],
     mappings: {


### PR DESCRIPTION
Merging this requires us to re-export existing users for them to show up in search

https://app.clickup.com/t/8686g763p


