### PR TITLE
Don't autosave values identical to the saved value

### DIFF
--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -174,9 +174,9 @@ export const EditorFormComponent = ({form, formType, formProps, document, name, 
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
   
   const saveBackup = useCallback((newContents: EditorContents) => {
-    const sameAsSaved = newContents.value === document?.[fieldName]?.ckEditorMarkup
+    const sameAsDatabaseSaved = newContents.value === document?.[fieldName]?.ckEditorMarkup
 
-    if (isBlank(newContents) || sameAsSaved) {
+    if (isBlank(newContents) || sameAsDatabaseSaved) {
       getLocalStorageHandlers(currentEditorType).reset();
       hasUnsavedDataRef.current.hasUnsavedData = false;
     } else {


### PR DESCRIPTION
There are a couple of ways the CKEditor autosave system can save a value of a post/comment/biography that's identical to the one that's already saved:
* You can edit an existing post/comment/biography, alter its text slightly, then change your mind and alter it back. The document notices it's being edited, so it autosaves whatever the text ends up as.
* ~~For comments, there's a bug where if you hit the Save button very soon after finishing typing in the text field, the text remains after you've hit Save. Hitting Save wipes the autosaved data as it should, but after the autosave timeout, it notices there's text in the text field, and it autosaves it.~~

~~Both of these~~ [The first of these] can be solved by just checking whether the value we're about to autosave is the same as the saved value, and resetting the autosaved data if so. ~~(The second case, with the lingering comment text, is also a bug that should be fixed, but that's a separate bug.)~~

Wait, never mind, it doesn't address the second case, because new top-level comments are independent of other saved top-level comments. This PR just handles the first case.

[Here's the ClickUp task](https://app.clickup.com/t/8685tau3p).

**Also implemented upstream in [this PR](https://github.com/ForumMagnum/ForumMagnum/pull/8308)**