### PR TITLE
Remove username validation error when username is changed

### DIFF
--- a/packages/lesswrong/components/users/WUUserOnboarding.tsx
+++ b/packages/lesswrong/components/users/WUUserOnboarding.tsx
@@ -131,6 +131,13 @@ const WUUserOnboarding: React.FC<WUUserOnboardingProps> = ({currentUser, classes
     setValidationError('')
   }
 
+  function updateUsername(username: string): void {
+    setUsername(username);
+    setServerValidationErrors(
+      serverValidationErrors.filter((err) => err?.graphQLErrors?.[0]?.data?.path !== 'username')
+    )
+  }
+
   async function handleSave() {
     try {
       if (validationError) return
@@ -190,7 +197,7 @@ const WUUserOnboarding: React.FC<WUUserOnboardingProps> = ({currentUser, classes
         <WUTextField
           label={'Username'}
           value={username}
-          onChange={(event) => setUsername(event.target.value)}
+          onChange={(event) => updateUsername(event.target.value)}
           onBlur={(_event) => validateUsername(username)}
           classes={classes}
           inputProps={{maxLength: 70}}


### PR DESCRIPTION
Jeremy's latest comment on [this ClickUp task](https://app.clickup.com/t/86866f10z) says that, if the username field has an error state due to matching the banned word list, editing the username should immediately remove the error state, rather than it persisting until the form is submitted again. This is a departure from how Vulcan forms are supposed to work, but fortunately, the onboarding page isn't a Vulcan form, so for this particular case, it's easy.