### PR TITLE
Disable Post and Comment previews

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -15,7 +15,7 @@ import { REVIEW_NAME_IN_SITU, REVIEW_YEAR, reviewIsActive, eligibleToNominate } 
 import { useCurrentTime } from '../../../lib/utils/timeUtil';
 import startCase from 'lodash/startCase';
 import FlagIcon from '@material-ui/icons/Flag';
-import { hideUnreviewedAuthorCommentsSettings } from '../../../lib/publicSettings';
+import {hideUnreviewedAuthorCommentsSettings, showLivePreviewsSetting} from '../../../lib/publicSettings'
 import { metaNoticeStyles } from './CommentsItemMeta';
 import { getVotingSystemByName } from '../../../lib/voting/votingSystems';
 import { useVote } from '../../votes/withVote';
@@ -185,7 +185,7 @@ const styles = (theme: ThemeType): JssStyles => ({
  *
  * Before adding more props to this, consider whether you should instead be adding a field to the CommentTreeOptions interface.
  */
-export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, collapsed, isParentComment, parentCommentId, scrollIntoView, toggleCollapse, setSingleLine, truncated, showPinnedOnProfile, parentAnswerId, enableGuidelines=true, showParentDefault=false, displayTagIcon=false, classes }: {
+export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, collapsed, isParentComment, parentCommentId, scrollIntoView, toggleCollapse, setSingleLine, truncated, showPinnedOnProfile, parentAnswerId, enableGuidelines=true, showParentDefault=false, displayTagIcon=false, showPostLivePreview = showLivePreviewsSetting.get, classes }: {
   treeOptions: CommentTreeOptions,
   comment: CommentsList|CommentsListWithParentMetadata,
   nestingLevel: number,
@@ -202,6 +202,7 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
   enableGuidelines?: boolean,
   showParentDefault?: boolean,
   displayTagIcon?: boolean,
+  showPostLivePreview?: () => boolean,
   classes: ClassesType,
 }) => {
   const commentItemRef = useRef<HTMLDivElement|null>(null); // passed into CommentsItemBody for use in InlineReactSelectionWrapper
@@ -385,7 +386,8 @@ export const CommentsItem = ({ treeOptions, comment, nestingLevel=1, isChild, co
             <Components.ForumIcon icon="Pin" className={classes.pinnedIcon} />
           </div>}
           {moderatedCommentId === comment._id && <FlagIcon className={classes.flagIcon} />}
-          {showPostTitle && !isChild && hasPostField(comment) && comment.post && <LWTooltip tooltip={false} title={<PostsPreviewTooltipSingle postId={comment.postId}/>}>
+          {showPostTitle && !isChild && hasPostField(comment) && comment.post && 
+            <LWTooltip tooltip={false} title={showPostLivePreview() && <PostsPreviewTooltipSingle postId={comment.postId}/>}>
               <Link className={classes.postTitle} to={commentGetPageUrlFromIds({postId: comment.postId, commentId: comment._id, postSlug: ""})}>
                 {comment.post.draft && (comment.post.deletedDraft ? "[Deleted] " : "[Draft] ")}
                 {comment.post.title}

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -10,7 +10,7 @@ import { useCommentByLegacyId } from '../comments/useComment';
 import { useHover } from '../common/withHover';
 import { usePostByLegacyId, usePostBySlug } from '../posts/usePost';
 import { isClient } from '../../lib/executionEnvironment';
-import {onSiteLinkSignifierSetting} from '../../lib/publicSettings.ts'
+import {onSiteLinkSignifierSetting, showLivePreviewsSetting} from '../../lib/publicSettings.ts'
 
 let missingLinkPreviewsLogged = new Set<string>();
 
@@ -227,12 +227,13 @@ const PostLinkCommentPreview = ({href, commentId, post, innerHTML, id}: {
 }
 const PostLinkCommentPreviewComponent = registerComponent('PostLinkCommentPreview', PostLinkCommentPreview);
 
-const PostLinkPreviewWithPost = ({classes, href, innerHTML, post, id, error}: {
+const PostLinkPreviewWithPost = ({classes, href, innerHTML, post, id, showLivePreview = showLivePreviewsSetting.get, error}: {
   classes: ClassesType,
   href: string,
   innerHTML: string,
   post: PostsList|null,
   id: string,
+  showLivePreview?: () => boolean,
   error: any,
 }) => {
   const { PostsPreviewTooltip, LWPopper } = Components
@@ -240,10 +241,8 @@ const PostLinkPreviewWithPost = ({classes, href, innerHTML, post, id, error}: {
   
   const hash = (href.indexOf("#")>=0) ? (href.split("#")[1]) : null;
 
-  if (!post) {
-    return <span {...eventHandlers}>
-      <Link to={href}  dangerouslySetInnerHTML={{__html: innerHTML}}/>
-    </span>
+  if (!post || !showLivePreview()) {
+    return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} onsite/>
   }
   return (
     <span {...eventHandlers}>
@@ -263,22 +262,21 @@ const PostLinkPreviewWithPostComponent = registerComponent('PostLinkPreviewWithP
   styles
 });
 
-const CommentLinkPreviewWithComment = ({classes, href, innerHTML, comment, post, id, error}: {
+const CommentLinkPreviewWithComment = ({classes, href, innerHTML, comment, post, id, showLivePreview = showLivePreviewsSetting.get, error}: {
   classes: ClassesType,
   href: string,
   innerHTML: string,
   comment: any,
   post: PostsList|null,
   id: string,
+  showLivePreview?: () => boolean,
   error: any,
 }) => {
   const { PostsPreviewTooltip, LWPopper } = Components
   const { eventHandlers, anchorEl, hover } = useHover();
 
-  if (!comment) {
-    return <span {...eventHandlers}>
-      <Link to={href} dangerouslySetInnerHTML={{__html: innerHTML}}/>
-    </span>
+  if (!comment || !showLivePreview()) {
+    return <Components.DefaultPreview href={href} innerHTML={innerHTML} id={id} onsite/>
   }
   return (
     <span {...eventHandlers}>

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -181,3 +181,4 @@ export const commentPermalinksAtTopSetting = new DatabasePublicSetting<boolean>(
 export const showNewUserIconSetting = new DatabasePublicSetting<boolean>('showNewUserIcon', true);
 export const sidebarLinksSetting = new DatabasePublicSetting<Array<{id: string, title: string, link: string, subItem: boolean}>>('sidebarLinks', []);
 export const onSiteLinkSignifierSetting = new DatabasePublicSetting<string>('onSiteLinkSignifier', '"°"');
+export const showLivePreviewsSetting = new DatabasePublicSetting<boolean>('showLivePreviews', true);


### PR DESCRIPTION
- Make onsiteLinkSignifier into a setting
- Put post and comment live previews behind the setting

settings: https://github.com/michaelkeenan/WUForumCredentials/pull/23

https://app.clickup.com/t/8686fa7zz
