### PR TITLE
Handle absolute onsite links like offsite links

### DIFF
--- a/packages/lesswrong/lib/reactRouterWrapper.tsx
+++ b/packages/lesswrong/lib/reactRouterWrapper.tsx
@@ -63,7 +63,7 @@ export const Link = ({eventProps, ...props}: LinkProps) => {
   const {to, href, ...otherProps} = props;
   const destinationUrl = to||href;
 
-  if (destinationUrl && typeof destinationUrl==='string' && isOffsiteLink(destinationUrl)) {
+  if (destinationUrl && typeof destinationUrl==='string' && isAbsoluteLink(destinationUrl)) {
     return <a href={destinationUrl} {...otherProps} onMouseDown={handleClick}/>
   } else {
     return <HashLink {...props} onMouseDown={handleClick}/>
@@ -87,6 +87,10 @@ function isOffsiteLink(url: string): boolean {
   } else {
     return false;
   }
+}
+
+function isAbsoluteLink(url: string): boolean {
+  return url.startsWith("http:") || url.startsWith("https:");
 }
 
 export const Redirect = reactRouter.Redirect;


### PR DESCRIPTION
[ClickUp task](https://app.clickup.com/t/8686m3fjk) about a bug where on-site links had broken URLs like "https://community.wakingup.com/posts/4ikorpg7BWj8hwdqC/https://community.wakingup.com/posts/FcGmftTz8oHzsbsf4/community-guidelines"

reactRouterWrapper checks whether a link is an onsite or offsite link and handles them differently. If it's offsite, it uses a regular <a> tag. If onsite, it sends on a code path that eventually uses [<Link>](https://reactrouter.com/en/main/components/link), which assumes that it's a relative path, so always prepends more stuff to the beginning. This change makes it treat all URLs that begin with "http:"/"https:" as offsite links.