### PR TITLE
Log request time

### DIFF
--- a/.platform/nginx/nginx.conf
+++ b/.platform/nginx/nginx.conf
@@ -20,7 +20,7 @@ http {
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                           '$status $body_bytes_sent "$http_referer" '
-                          '"$http_user_agent" "$http_x_forwarded_for"';
+                          '"$http_user_agent" "$http_x_forwarded_for" $request_time';
 
     include  conf.d/*.conf;
 


### PR DESCRIPTION
The site *seems* to be fine, but Beanstalk keeps reporting that the site is in and out of a Degraded state due to 25+% of queries taking over 30 seconds to complete. This PR makes nginx record the request time for each query.

I suspect[1] that only the ELB health checker queries are the long ones (which would explain why I haven't noticed long queries and no-one's reported them), though I have no theory for why they'd take so long; they just send GET requests to '/'.

**Update**: [1] I was wrong; it was the /notificationEvents calls, which do long polling.