### PR TITLE
Un-hardcode frontpage and curation score bonus

### DIFF
--- a/packages/lesswrong/lib/scoring.ts
+++ b/packages/lesswrong/lib/scoring.ts
@@ -21,8 +21,8 @@ type SubforumCommentBonus = typeof defaultSubforumCommentBonus;
 
 // LW (and legacy) time decay algorithm settings
 const timeDecayFactorSetting = new DatabasePublicSetting<number>('timeDecayFactor', 1.15)
-const frontpageBonusSetting = new DatabasePublicSetting<number>('frontpageScoreBonus', 10)
-const curatedBonusSetting = new DatabasePublicSetting<number>('curatedScoreBonus', 10)
+export const frontpageBonusSetting = new DatabasePublicSetting<number>('frontpageScoreBonus', 10)
+export const curatedBonusSetting = new DatabasePublicSetting<number>('curatedScoreBonus', 10)
 const subforumCommentBonusSetting = new DatabasePublicSetting<SubforumCommentBonus>(
   'subforumCommentBonus',
   defaultSubforumCommentBonus,

--- a/packages/lesswrong/server/updateScores.ts
+++ b/packages/lesswrong/server/updateScores.ts
@@ -6,6 +6,8 @@ import {
   TIME_DECAY_FACTOR,
   getSubforumScoreBoost,
   SCORE_BIAS,
+  frontpageBonusSetting,
+  curatedBonusSetting,
 } from '../lib/scoring';
 import * as _ from 'underscore';
 import { Posts } from "../lib/collections/posts";
@@ -140,8 +142,8 @@ const getPgCollectionProjections = (collectionName: CollectionNameString) => {
         THEN "postedAt"
         ELSE "frontpageDate" END) AS "scoreDate"`;
       proj.baseScore = `("baseScore" +
-        (CASE WHEN "frontpageDate" IS NULL THEN 0 ELSE 10 END) +
-        (CASE WHEN "curatedDate" IS NULL THEN 0 ELSE 10 END)) AS "baseScore"`;
+        (CASE WHEN "frontpageDate" IS NULL THEN 0 ELSE ${frontpageBonusSetting.get()} END) +
+        (CASE WHEN "curatedDate" IS NULL THEN 0 ELSE ${curatedBonusSetting.get()} END)) AS "baseScore"`;
       break;
     case "Comments":
       const {base, magnitude, duration, exponent} = getSubforumScoreBoost();


### PR DESCRIPTION
The scoring algorithm is supposed to use frontpageBonusSetting and curatedBonusSetting, as it does in scoring.ts/recalculateScore. But the bulk score updates that run every 30 seconds had these values hardcoded as 10. This PR fixes that.

This change will probably have a big effect on score rankings when it goes live. With these values hardcoded, a post with 4 points and a post with 2 points were being ranked as if they had 14 points and 12 points, a small relative difference. After this change, they'll be ranked as 4 and 2. We'll want to watch the ranking and possibly change the timeDecayFactor setting if we don't like the rankings.

[Here's the ClickUp task](https://app.clickup.com/t/8686nn7kk).