### PR TITLE
Use a setting for the score bias constant

### DIFF
--- a/packages/lesswrong/lib/scoring.ts
+++ b/packages/lesswrong/lib/scoring.ts
@@ -21,6 +21,7 @@ type SubforumCommentBonus = typeof defaultSubforumCommentBonus;
 
 // LW (and legacy) time decay algorithm settings
 const timeDecayFactorSetting = new DatabasePublicSetting<number>('timeDecayFactor', 1.15)
+const scoreBiasSetting = new DatabasePublicSetting<number>('scoreBias', 2);
 export const frontpageBonusSetting = new DatabasePublicSetting<number>('frontpageScoreBonus', 10)
 export const curatedBonusSetting = new DatabasePublicSetting<number>('curatedScoreBonus', 10)
 const subforumCommentBonusSetting = new DatabasePublicSetting<SubforumCommentBonus>(
@@ -40,7 +41,7 @@ export const TIME_DECAY_FACTOR = timeDecayFactorSetting;
 // Basescore bonuses for various categories
 export const FRONTPAGE_BONUS = frontpageBonusSetting;
 export const CURATED_BONUS = curatedBonusSetting;
-export const SCORE_BIAS = 2;
+export const SCORE_BIAS = scoreBiasSetting;
 
 export const getSubforumScoreBoost = (): SubforumCommentBonus => {
   const defaultBonus = {...defaultSubforumCommentBonus};
@@ -81,7 +82,7 @@ export const recalculateScore = (item: VoteableType) => {
     baseScore = baseScore + frontpageBonus + curatedBonus + subforumBonus;
 
     // HN algorithm
-    const newScore = Math.round((baseScore / Math.pow(ageInHours + SCORE_BIAS, TIME_DECAY_FACTOR.get()))*1000000)/1000000;
+    const newScore = Math.round((baseScore / Math.pow(ageInHours + SCORE_BIAS.get(), TIME_DECAY_FACTOR.get()))*1000000)/1000000;
 
     return newScore;
   } else {
@@ -150,7 +151,7 @@ export const timeDecayExpr = () => {
         ]},
         60 * 60 * 1000
       ] }, // Age in hours
-      SCORE_BIAS,
+      SCORE_BIAS.get(),
     ]},
     TIME_DECAY_FACTOR.get()
   ]}

--- a/packages/lesswrong/server/updateScores.ts
+++ b/packages/lesswrong/server/updateScores.ts
@@ -21,7 +21,7 @@ const INACTIVITY_THRESHOLD_DAYS = 30;
 
 const getSingleVotePower = () =>
   // score increase amount of a single vote after n days (for n=100, x=0.000040295)
-  1 / Math.pow((INACTIVITY_THRESHOLD_DAYS * 24) + SCORE_BIAS, TIME_DECAY_FACTOR.get());
+  1 / Math.pow((INACTIVITY_THRESHOLD_DAYS * 24) + SCORE_BIAS.get(), TIME_DECAY_FACTOR.get());
 
 interface BatchUpdateParams {
   inactive?: boolean;
@@ -186,7 +186,7 @@ const getBatchItemsPg = async <T extends DbObject>(collection: CollectionBase<T>
       1.0 / POW(${ageHours} + $2, $3) AS "singleVotePower"
     ) ns
     ${forceUpdate ? "" : 'WHERE ABS("score" - ns."newScore") > ns."singleVotePower" OR NOT q."inactive"'}
-  `, [INACTIVITY_THRESHOLD_DAYS, SCORE_BIAS, TIME_DECAY_FACTOR.get()], "read");
+  `, [INACTIVITY_THRESHOLD_DAYS, SCORE_BIAS.get(), TIME_DECAY_FACTOR.get()], "read");
 }
 
 const getBatchItems = async <T extends DbObject>(collection: CollectionBase<T>, inactive: boolean, forceUpdate: boolean) =>


### PR DESCRIPTION
Now we're un-hardcoding the score bias constant as discussed in [this Slack thread](https://lightconeoffices.slack.com/archives/C05MHUVM2SY/p1701904349037969).

Jeremy and I are going to experiment with the exact settings of timeDecayFactor and scoreBias live, so there's no associated ForumCredentials PR yet.