### PR TITLE
Change default comment order to a setting

### DIFF
--- a/packages/lesswrong/lib/collections/comments/helpers.ts
+++ b/packages/lesswrong/lib/collections/comments/helpers.ts
@@ -6,8 +6,7 @@ import { userCanDo } from '../../vulcan-users/permissions';
 import { userGetDisplayName } from "../users/helpers";
 import { tagGetCommentLink } from '../tags/helpers';
 import { TagCommentType } from './types';
-import { hideUnreviewedAuthorCommentsSettings } from '../../publicSettings';
-import { forumSelect } from '../../forumTypeUtils';
+import { defaultCommentOrderSetting, hideUnreviewedAuthorCommentsSettings } from '../../publicSettings';
 
 // Get a comment author's name
 export async function commentGetAuthorName(comment: DbComment): Promise<string> {
@@ -82,13 +81,9 @@ export const commentDefaultToAlignment = (currentUser: UsersCurrent|null, post: 
 }
 
 export const commentGetDefaultView = (post: PostsDetails|DbPost|null, currentUser: UsersCurrent|null): CommentsViewName => {
-  const fallback = forumSelect({
-    AlignmentForum: "afPostCommentsTop",
-    EAForum: "postCommentsMagic",
-    WakingUp: "postCommentsMagic",
-    default: "postCommentsTop",
-  });
-  return (post?.commentSortOrder as CommentsViewName) || (currentUser?.commentSorting as CommentsViewName) || fallback
+  return (post?.commentSortOrder as CommentsViewName) ||
+    (currentUser?.commentSorting as CommentsViewName) ||
+    defaultCommentOrderSetting.get();
 }
 
 export const commentGetKarma = (comment: CommentsList|DbComment): number => {

--- a/packages/lesswrong/lib/publicSettings.ts
+++ b/packages/lesswrong/lib/publicSettings.ts
@@ -166,3 +166,4 @@ export const performanceMetricLoggingBatchSize = new DatabasePublicSetting<numbe
 export const showSuggestionToCommentIfNoCommentsSetting = new DatabasePublicSetting<boolean>('post.showSuggestionToCommentIfNoComments', true);
 export const postCommentCountTruncateThresholdSetting = new DatabasePublicSetting<number>('post.commentCountTruncateThreshold', 70);
 export const showConversationOptionsSetting = new DatabasePublicSetting<boolean>('conversation.showOptions', true);
+export const defaultCommentOrderSetting = new DatabasePublicSetting<string>('post.defaultCommentOrder', 'postCommentsTop');


### PR DESCRIPTION
This PR changes the default comment order to use a new post.defaultCommentOrder setting.

[ClickUp task](https://app.clickup.com/t/8686r8qd3).

This is intended for merging upstream (which I'll arrange after it's finalized and approved here). EAForum will want their setting to be "postCommentsMagic", and AlignmentForum will want "afPostCommentsTop". LessWrong and WakingUp will use the default, "postCommentsTop".