### PR TITLE
Make the displayName validation send the user-friendly error message

### DIFF
--- a/packages/lesswrong/lib/collections/users/username.ts
+++ b/packages/lesswrong/lib/collections/users/username.ts
@@ -1,6 +1,8 @@
 import {SimpleValidationError} from '../../vulcan-lib'
 import badWords from '../../badWords.json'
 
+export const usernameTakenError = 'Sorry, that username is already taken.'
+
 export const usernameIsBadWord = (username: string) => {
   return badWords.includes(username.toLowerCase().trim()) || badWords.includes(username.toLowerCase().replace(/[0-9]/g, '').trim())
 }
@@ -13,7 +15,7 @@ export const usernameIsTaken = async (userCollection: UsersCollection, currentUs
 export const assertUsernameIsNotTaken = async (userCollection: UsersCollection, currentUser: DbUser, username: string) => {
   if (await usernameIsTaken(userCollection, currentUser, username)) {
     throw new SimpleValidationError({
-      message: 'Sorry, that username is already taken.',
+      message: usernameTakenError,
       data: {path: 'username'},
     })
   }

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -33,9 +33,10 @@ import {userFindOneByEmail} from "../commonQueries";
 import { hasDigests } from '../../lib/betas';
 import { addToSendgridList, removeFromSendgridList } from '../emails/sendgridListManagement';
 import { sendEmailSendgridTemplate } from '../emails/sendEmail';
-import { throwValidationError } from '../vulcan-lib';
+import {SimpleValidationError, throwValidationError} from '../vulcan-lib'
 import ElectionVotes from '../../lib/collections/electionVotes/collection';
 import { eaGivingSeason23ElectionName } from '../../lib/eaGivingSeason';
+import {usernameTakenError} from '../../lib/collections/users/username.ts'
 
 const MODERATE_OWN_PERSONAL_THRESHOLD = 50
 const TRUSTLEVEL1_THRESHOLD = 2000
@@ -559,7 +560,10 @@ getCollectionHooks("Users").updateBefore.add(async function UpdateDisplayName(da
       });
     }
     if (await Users.findOne({displayName: data.displayName})) {
-      throw new Error("This display name is already taken");
+      throw new SimpleValidationError({
+        message: usernameTakenError,
+        data: {path: 'displayName'},
+      })
     }
   }
   return data;


### PR DESCRIPTION
A fix to one of the causes of https://app.clickup.com/t/8686njyqb, I don't entirely understand how we get here, but I outlined a plausible story in the ticket. 


