### PR TITLE
Make sure to account for oldSlugs when picking a unique slug for new users

### DIFF
--- a/packages/lesswrong/server/resolvers/userResolvers.ts
+++ b/packages/lesswrong/server/resolvers/userResolvers.ts
@@ -272,7 +272,7 @@ addGraphQLResolvers({
           first_name: firstName,
           last_name: lastName,
           mapLocation,
-          slug: await Utils.getUnusedSlugByCollectionName('Users', slugify(username)),
+          slug: await Utils.getUnusedSlugByCollectionName('Users', slugify(username), true),
           subscribedToDigest: subscribeToDigest,
           disableUnsolicitedMessages,
           acceptedTos,


### PR DESCRIPTION
Make sure to account for oldSlugs when picking a unique slug for new users