### PR TITLE
Make post titles real links so you can middle-click-open them

### DIFF
--- a/packages/lesswrong/components/posts/EAPostsItem.tsx
+++ b/packages/lesswrong/components/posts/EAPostsItem.tsx
@@ -294,7 +294,7 @@ const EAPostsItem = ({
                   showIcons,
                 }}
                 read={isRead && !showReadCheckbox}
-                isLink={false}
+                isLink={true}
                 className={classes.title}
               />
               <div className={classes.meta}>


### PR DESCRIPTION
I considered making this a setting, but this is accomplished a different way upstream, and our EAPostsItem file is heavily modified anyway so keeping it upstream-compatible doesn't seem pressing.

[ClickUp task](https://app.clickup.com/t/8686ne3mj).