### PR TITLE
Don't include posts with no comments in Latest Comment view

### DIFF
--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -561,6 +561,7 @@ Posts.addView("new", (terms: PostsViewTerms) => ({
 }))
 
 Posts.addView("recentComments", (terms: PostsViewTerms) => ({
+  selector: { commentCount: { $gt: 0 } },
   options: {sort: sortings.recentComments}
 }))
 


### PR DESCRIPTION
Every post gets a value for its lastCommentedAt field on creation (though it's a few milliseconds off the createdAt time), hence why sorting by lastCommentedAt shows recent posts first. But we can just exclude posts with commentCount = 0, and that's what this PR does.

[Here's the ClickUp task](https://app.clickup.com/t/8686p2mbf).