### PR TITLE
Show friendly error message to user for blocked message errors

### DIFF
--- a/packages/lesswrong/lib/vulcan-lib/errors.ts
+++ b/packages/lesswrong/lib/vulcan-lib/errors.ts
@@ -184,7 +184,16 @@ export const RateLimitError = createError(
   }
 )
 
-const whitelistedErrors = ["SimpleValidationError", "AuthorizationError", "RateLimitError"]
+// Use UserFacingError for miscellaneous errors with error messages that should be shown to the user.
+// (The default is the generic error message, but that's intended to be overwritten.)
+export const UserFacingError = createError(
+  'UserFacingError',
+  {
+    message: GENERIC_ERROR_MESSAGE,
+  }
+)
+
+const whitelistedErrors = ["SimpleValidationError", "AuthorizationError", "RateLimitError", "UserFacingError"]
 
 // Most errors shouldn't be shown to the user. Only a few specific ones should,
 // and they're whitelisted here.


### PR DESCRIPTION
[ClickUp task](https://app.clickup.com/t/8686u7fzf).

I've added a new type of error, UserFacingError, for miscellaneous errors with messages that should be shown to the user. It bugs me that it mixes classifications a bit; "Authorization" in "AuthorizationError" describes the type of error it is, not the way it's displayed. But this error isn't really an authorization error (well, kind of, but calling it that seems more likely to mislead when people are going to expect AuthorizationErrors to be about logins), and I see no benefit to creating narrower error message classes for lots of cases, when they're all just things to be shown to the user for the user to solve. So, UserFacingError?

<img width="818" alt="Screenshot 2023-12-27 at 4 56 23 PM" src="https://github.com/wakingupllc/wakingup-community/assets/675520/7936eb51-6cd3-47c6-a86e-8a2a4424ee87">
