### PR TITLE
Change commentSortOrder Post field to a dropdown

### DIFF
--- a/packages/lesswrong/lib/collections/posts/schema.tsx
+++ b/packages/lesswrong/lib/collections/posts/schema.tsx
@@ -32,6 +32,7 @@ import { crosspostKarmaThreshold } from '../../publicSettings';
 import { getDefaultViewSelector } from '../../utils/viewUtils';
 import GraphQLJSON from 'graphql-type-json';
 import { addGraphQLSchema } from '../../vulcan-lib/graphql';
+import { getCommentViewOptions } from '../../commentViewOptions';
 
 const urlHintText = isEAForum
     ? 'UrlHintText'
@@ -2350,6 +2351,8 @@ const schema: SchemaType<DbPost> = {
     canRead: ['guests'],
     canCreate: ['admins'],
     canUpdate: ['admins'],
+    control: 'select',
+    options: getCommentViewOptions(),
     optional: true,
     group: formGroups.adminOptions,
   },


### PR DESCRIPTION
[From Jeremy on Slack](https://lightconeoffices.slack.com/archives/C05MHUVM2SY/p1703787239932629):

Jeremy Carter
Admins have this post editing field called "Comment Sort Order"
Based on the name, I would assume it's a field for changing the default sorting order for comments on a post, which seems potentially useful. But it's free text entry, and typing out a sort option like Newest does nothing. Is this just something we haven't enabled?
Comment-Sort-Order.png

Michael Keenan
Yep that’s what it does, though it uses the internal constants to label the possible orders:
'postCommentsMagic'
'postCommentsTop'
'postCommentsRecentReplies'
'postCommentsNew'
'postCommentsOld'
'postCommentsBest'
'postCommentsDeleted'

Jeremy Carter
So, uh, why isn't that a dropdown? :thinking_face:

Michael Keenan
A comment says “In practice this is almost never set, less than 1/1000 posts have it set”
so I’m guessing it was something someone put together once for some mostly one-off purpose, but wasn’t used often enough to create a nice UI for the admins who’d occasionally use it

Jeremy Carter
Maybe a more important question: would it be negligible to turn it into a dropdown? So that admins don't have to remember constants :sweat_smile:

Michael Keenan
Dropdown is probably pretty easy, one moment while I confirm that…

Jeremy Carter
Cool. FWIW, I'm thinking of one potential use case, where it would be used once a month, so if it takes five minutes to turn it into a dropdown, might as well. If not, no worries (edited) 

Michael Keenan
Confirmed: it’s easy; I’ve prototyped it and will probably have it finalized within five minutes