### PR TITLE
Send deactivation email, fix error message display, change wording

### DIFF
--- a/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
+++ b/packages/lesswrong/components/ea-forum/users/EAUsersProfile.tsx
@@ -466,7 +466,7 @@ const EAUsersProfile = ({terms, slug, subscriptionsEnabled = true, postSortingEn
         <div className={classNames(classes.section, classes.mainSection)}>
           <EAUsersProfileImage user={user} />
           <Typography variant="headline" className={classNames(classes.username, {[classes.deletedUsername]: user.deleted})}>
-            {username}{user.deleted && <span className={classes.accountDeletedText}>(account deleted)</span>}
+            {username}{user.deleted && <span className={classes.accountDeletedText}>(Account Deactivated)</span>}
             {showDonatedFlair(user) &&
               <LWTooltip
                 placement="bottom-start"

--- a/packages/lesswrong/components/users/WULoginForm.tsx
+++ b/packages/lesswrong/components/users/WULoginForm.tsx
@@ -1,4 +1,4 @@
-import { Components, registerComponent } from '../../lib/vulcan-lib';
+import { Components, registerComponent, isGenericError } from '../../lib/vulcan-lib';
 import React, { useState, useRef, useEffect } from 'react';
 import { gql, useMutation } from '@apollo/client';
 import classNames from 'classnames';
@@ -6,6 +6,7 @@ import OTPInput, { OTPInputMethods } from './OTPInput';
 import SimpleSchema from 'simpl-schema';
 import { cdnAssetUrl } from '../../lib/routeUtil';
 import {devWakingUpCodeSetting} from '../../lib/publicSettings'
+import FormattedMessage from '../../lib/vulcan-i18n/message';
 
 const styles = (theme: ThemeType): JssStyles => ({
   root: {
@@ -57,6 +58,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     [theme.breakpoints.down('sm')]: {
       marginLeft: 0,
       marginRight: 0
+    },
+    "& a": {
+      color: theme.palette.error.main,
     }
   },
   options: {
@@ -272,7 +276,8 @@ export const WULoginForm = ({ startingState = "requestCode", classes }: WULoginF
           value={currentActionToButtonText[currentAction]}
           disabled={oneTimeCode.length !== 4} />
       </>}
-      {errorMessage() && <div className={classes.error}>{errorMessage()}
+      {errorMessage() && <div className={classes.error}>
+        <FormattedMessage id={errorMessage()} defaultMessage={errorMessage()} html={isGenericError(errorMessage())} />
         {showSendNewCodeLink() && <>&nbsp;<a href="#" onClick={() => { void requestNewCode() }}>Send a new code</a>.</>}
       </div>}
       {(error || currentAction === "enterCode") && <a href="/" className={classes.returnToLogin}>Return to login</a>}

--- a/packages/lesswrong/server/callbacks/userCallbacks.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbacks.tsx
@@ -179,7 +179,7 @@ getCollectionHooks("Users").updateAsync.add(function updateUserMayTriggerReview(
  */
 getCollectionHooks("Users").updateAsync.add(function sendDeactivationConfirmationEmail({oldDocument, newDocument, currentUser}: UpdateCallbackProperties<DbUser>) {
   if (!isWakingUp) return
-  if (!oldDocument.deleted && newDocument.deleted && currentUser?._id === newDocument._id) {
+  if (!oldDocument.deleted && newDocument.deleted) {
     const sendgridData = {
       user: newDocument,
       to: getUserEmail(newDocument),

--- a/packages/lesswrong/server/forumSpecificMiddleware/wuMiddleware.ts
+++ b/packages/lesswrong/server/forumSpecificMiddleware/wuMiddleware.ts
@@ -363,6 +363,8 @@ const authenticationResolvers = {
       if (isValidWuUser(wuUser)) {
         const user = await syncOrCreateWuUser(wuUser)
 
+        if (user?.deleted) throw new AuthorizationError({ message: deletedAccountMessage(email), internalData: { error: "User has been deleted" }});
+
         assertCodeRequestNotLocked(user);
         assertCodeEntryNotLocked(user);
 


### PR DESCRIPTION
(Untangled version of the previous PR)

Addressing [Jeremy's QA comment](https://app.clickup.com/t/8686pk7uh?comment=90110034328195):

> Username appears as [anonymous] on posts and comments, but should appear as [Removed] 

(I'd neglected to load the new staging settings, solved)

> Did not receive automated account deactivation email.

The sendDeactivationConfirmationEmail callback had a condition to only send this if you deactivated yourself; I've removed that.

> The error message informing the user that the account has been deactivated appeared **after** email code entry. It should instead appear on the page where the user enters their email. User should not be sent a login code if their account is deactivated.

I moved this check to the login request (and also adjusted the login form error message display code to show the generic message with a correctly formatted link, if it appears)

> In admin view, crossed out username is labeled (account deleted) but should be labeled (Account Deactivated) for accuracy. Same for hover text displayed when an admin hovers over a deactivated account's username on a post or comment.

Fixed