### PR TITLE
Use wuEmojiPalette for react labels

### DIFF
--- a/packages/lesswrong/components/votes/EAReactsSection.tsx
+++ b/packages/lesswrong/components/votes/EAReactsSection.tsx
@@ -13,10 +13,12 @@ import { useCurrentUser } from "../common/withUser";
 import { useDialog } from "../common/withDialog";
 import {
   eaAnonymousEmojiPalette,
-  eaEmojiPalette,
   EmojiOption,
   getEmojiMutuallyExclusivePartner,
 } from "../../lib/voting/eaEmojiPalette";
+import {
+  wuEmojiPalette,
+} from "../../lib/voting/wuEmojiPalette";
 import type { VotingProps } from "./votingProps";
 import Menu from "@material-ui/core/Menu";
 import classNames from "classnames";
@@ -128,7 +130,7 @@ const getCurrentReactions = <T extends VoteableTypeClient>(
     return result;
   }
 
-  for (const emojiOption of eaEmojiPalette) {
+  for (const emojiOption of wuEmojiPalette) {
     if ((extendedScore[emojiOption.name] ?? 0) > 0) {
       result.push({
         emojiOption,


### PR DESCRIPTION
Jeremy on Slack:

> Any chance we could hotfix this? "Heart" appears as the text label on hover, rather than "Love"
