### PR TITLE
Prevent messages to deactivated users; update admin hover text

### DIFF
--- a/packages/lesswrong/components/users/UserNameDeleted.tsx
+++ b/packages/lesswrong/components/users/UserNameDeleted.tsx
@@ -40,7 +40,7 @@ const UserNameDeletedWithAdminHover = ({user}: {
   return <span {...eventHandlers}>
     <LWTooltip
       title={<div>
-        This user account has been deleted. The username is only visible to site admins, and only visible on hover-over.
+        This user account has been deactivated. The username is only visible to site admins, and only visible on hover-over.
       </div> }
       inlineBlock={false}
     >


### PR DESCRIPTION
This PR:
* Updates hover text for admins about deactivated users
* Prevents people messaging deactivated users (this part also rearranges code so admins can't message non-existent users either)

[ClickUp comment](https://app.clickup.com/t/8686pk7uh?comment=90110034451589)