### PR TITLE
Update message when user messages deactivated account

### DIFF
--- a/packages/lesswrong/server/callbacks/messageCallbacks.ts
+++ b/packages/lesswrong/server/callbacks/messageCallbacks.ts
@@ -33,7 +33,7 @@ getCollectionHooks("Messages").createBefore.add(async function checkMessagePermi
     if (!participant) throw new Error("Recipient doesn't exist");
     if (participant.deleted) {
       throw new UserFacingError({
-        message: `${participant.username} has been deactivated.`
+        message: 'This account has been deactivated.'
       })
     }
     if (currentUser?.isAdmin) continue;


### PR DESCRIPTION
This PR uses the actually correct message when messaging deactivated accounts: "This account has been deactivated."

https://app.clickup.com/t/8686pk7uh?comment=90110034451589&threadedComment=90110034675269