### PR TITLE
Fill one-time-code if it's supplied

### DIFF
--- a/packages/lesswrong/components/users/WULoginForm.tsx
+++ b/packages/lesswrong/components/users/WULoginForm.tsx
@@ -175,7 +175,7 @@ export const WULoginForm = ({ classes }: WULoginFormProps) => {
   const startingState = (pathname === '/code' && emailParam !== '') ? 'enterCode' : 'requestCode';
 
   const [email, setEmail] = useState<string>(emailParam)
-  const [oneTimeCode, setOneTimeCode] = useState<string>("")
+  const [oneTimeCode, setOneTimeCode] = useState<string>(params.get('pin') || '')
   const [currentAction, setCurrentAction] = useState<possibleActions>(startingState)
   const [requestAnotherCode, setRequestAnotherCode] = useState<boolean>(false)
   // This currentActionToMutation thing is regrettably complicated, but the point


### PR DESCRIPTION
Tiny PR that enables the third potential fix from the email login flow [ClickUp task](https://app.clickup.com/t/8686vkhcb), a slightly nicer UX:

"Implement deep linking functionality where the code is passed back to the app directly from the email. When the user clicks the link in their email, the app opens directly to the code input screen with the code already filled in."