### PR TITLE
Fix seconds-from-now moment locale wording

### DIFF
--- a/packages/lesswrong/components/momentjs.ts
+++ b/packages/lesswrong/components/momentjs.ts
@@ -4,7 +4,11 @@ moment.defineLocale('descriptive-durations', {
     relativeTime: {
         future: "%s",
         past:   "%s ago",
-        s:      "%d second",
+        s: function (number, withoutSuffix, key, isFuture) {
+            // 's' is usually for "a few seconds", but we want to be precise, hence this function
+            if (number === 1) return '1 second';
+            return number + ' seconds';
+        },
         ss:     "%d seconds",
         m:      "a minute",
         mm:     "%d minutes",


### PR DESCRIPTION
Post rate limits had messages with bad pluralization for seconds, e.g. "Please wait 4 second before posting again."

Turns out this is because Moment has a time range (designated "s", as distinguished from "ss") intended for messages like "a few seconds", and I'd mistakenly thought it was for "1 second" and set it to "%d s". This PR uses a function to get the pluralization right.

[ClickUp task](https://app.clickup.com/t/8686dwwga).