### PR TITLE
Fix tag-less post search hits throwing errors

### DIFF
--- a/packages/lesswrong/components/ea-forum/EAPostMeta.tsx
+++ b/packages/lesswrong/components/ea-forum/EAPostMeta.tsx
@@ -105,7 +105,7 @@ const EAPostMeta = ({post, useEventStyles, showAuthorTooltip = true, className, 
           {" · "}{post.readTimeMinutes || 1}m read
         </span>}
         {categoriesEnabledSetting.get() 
-          && post.tags[0] 
+          && post.tags?.[0]
           && <span>{' · '}{post.tags[0].name}</span>}
       </div>
     </div>


### PR DESCRIPTION
Beware that I haven't tested this fix properly! I've never gotten search working in my dev environment.

But still, I think this is probably the right fix for [this ClickUp task bug](https://app.clickup.com/t/86870x4pc). When post search its have no tags, they show up as `Error: TypeError: Cannot read properties of null (reading '0')`, because `post.tags` is null and it's trying to get `post.tags[0]`.